### PR TITLE
Collector + sync_service tests (PR 4/6)

### DIFF
--- a/tests/integration/test_collector.py
+++ b/tests/integration/test_collector.py
@@ -1,0 +1,163 @@
+"""Integration tests for collector.py functions that touch the DB."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+
+# ── Reset collector state between tests ──────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_collector_state():
+    from app.services import collector
+    state_dicts = (
+        collector._consec_failures, collector._cooldown_until,
+        collector._last_failure_at, collector._last_seen_ts,
+        collector._prev_status, collector._offline_retry_count,
+        collector._offline_alert_count, collector._stall_count,
+        collector._stall_alerted, collector._prev_dns_queries_today,
+        collector._prev_watermark_for_stall,
+        collector._vip_last_advance_seq, collector._vip_advance_streak,
+        collector._vip_active_node, collector._vip_group_stall_alerted,
+        collector._site_poll_seq,
+    )
+    for d in state_dicts:
+        d.clear()
+    yield
+    for d in state_dicts:
+        d.clear()
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def site(db_session):
+    from app.models.site import Site
+    s = Site(name="Test", slug="test", is_active=True, is_main=True)
+    db_session.add(s)
+    await db_session.commit()
+    await db_session.refresh(s)
+    return s
+
+
+@pytest.fixture
+async def instance(db_session, site):
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    from app.models.pihole import PiholeInstance
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+
+    inst = PiholeInstance(
+        site_id=site.id, name="pihole-1",
+        url="http://pihole.test", api_password="pw",
+        is_active=True,
+    )
+    db_session.add(inst)
+    await db_session.commit()
+    await db_session.refresh(inst)
+    return inst
+
+
+# ── prune_inactive_state ─────────────────────────────────────────────────────
+
+
+async def test_prune_inactive_state_drops_state_for_deactivated_instances(
+    instance, db_session,
+):
+    """When config_loader deactivates an instance (is_active=False),
+    the per-instance dicts must shed its key so the next reload picks
+    up clean state."""
+    from app.services import collector
+
+    key = str(instance.id)
+    collector._last_seen_ts[key] = 12345.0
+    collector._prev_status[key] = "online"
+    collector._consec_failures[key] = 2
+
+    instance.is_active = False
+    db_session.add(instance)
+    await db_session.commit()
+
+    await collector.prune_inactive_state()
+
+    assert key not in collector._last_seen_ts
+    assert key not in collector._prev_status
+    assert key not in collector._consec_failures
+
+
+async def test_prune_inactive_state_keeps_state_for_active_instances(
+    instance,
+):
+    from app.services import collector
+
+    key = str(instance.id)
+    collector._last_seen_ts[key] = 12345.0
+
+    await collector.prune_inactive_state()
+
+    # Active instance — state must survive.
+    assert collector._last_seen_ts[key] == 12345.0
+
+
+# ── cleanup_old_data ─────────────────────────────────────────────────────────
+
+
+async def test_cleanup_old_data_removes_rows_past_retention(
+    instance, db_session,
+):
+    """Stats snapshots, query logs, and revoked-token rows older than
+    DATA_RETENTION_DAYS get deleted nightly."""
+    from app.config import settings
+    from app.models.pihole import StatsSnapshot, QueryLog
+    from app.models.user import RevokedToken
+    from app.services import collector
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=settings.data_retention_days + 1)
+
+    db_session.add_all([
+        StatsSnapshot(
+            instance_id=instance.id, collected_at=cutoff, status="online",
+        ),
+        QueryLog(
+            instance_id=instance.id, timestamp=cutoff,
+            domain="ancient.example", status="OK",
+        ),
+        RevokedToken(jti="ancient-jti", expires_at=cutoff),
+    ])
+    # Recent rows must SURVIVE.
+    recent = datetime.now(timezone.utc) - timedelta(days=1)
+    db_session.add_all([
+        StatsSnapshot(
+            instance_id=instance.id, collected_at=recent, status="online",
+        ),
+        QueryLog(
+            instance_id=instance.id, timestamp=recent,
+            domain="recent.example", status="OK",
+        ),
+    ])
+    await db_session.commit()
+
+    await collector.cleanup_old_data()
+
+    # Use a fresh session — the autouse db_session has the deleted rows
+    # in its identity map.
+    from app.database import AsyncSessionLocal
+    async with AsyncSessionLocal() as fresh:
+        snapshots = (await fresh.execute(select(StatsSnapshot))).scalars().all()
+        queries = (await fresh.execute(select(QueryLog))).scalars().all()
+        tokens = (await fresh.execute(select(RevokedToken))).scalars().all()
+
+    # Only the recent rows should remain.
+    assert len(snapshots) == 1
+    assert len(queries) == 1
+    assert queries[0].domain == "recent.example"
+    assert len(tokens) == 0

--- a/tests/integration/test_sync_service.py
+++ b/tests/integration/test_sync_service.py
@@ -1,0 +1,314 @@
+"""Integration tests for sync_service.run_sync orchestration.
+
+run_sync is the multi-step ritual that has bitten MyPi in production
+several times — gravity on master → teleporter export → broadcast to
+replicas → gravity on replicas. Mocks the Pi-hole HTTP surface with
+respx; the master + replicas live in a real testcontainer DB.
+"""
+from __future__ import annotations
+
+import io
+import uuid
+import zipfile
+
+import httpx
+import pytest
+
+
+def _valid_teleporter_zip() -> bytes:
+    """Construct a >1KB valid ZIP archive that the validator accepts.
+    Padding is needed because _validate_teleporter_zip refuses
+    sub-1KB responses (truncation guard)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("pihole.toml", b"x" * 2048)
+    return buf.getvalue()
+
+
+# ── Reset collector + sync state between tests ───────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    from app.services import collector, sync_service
+    for d in (
+        collector._consec_failures, collector._cooldown_until,
+        collector._last_failure_at,
+    ):
+        d.clear()
+    sync_service._state_by_site.clear()
+    sync_service._lock_by_site.clear()
+    sync_service._last_blocklist_by_site.clear()
+    yield
+
+
+# ── Mute Pushover ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _stub_pushover(monkeypatch):
+    """run_sync calls pushover_service.notify_sync_failure on errors —
+    the Pushover client would try to make outbound HTTP calls. Stub
+    every notify_* function to a no-op so tests don't need a Pushover
+    mock alongside the Pi-hole respx mocks."""
+    from app.services import pushover
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    for name in (
+        "notify_sync_failure", "notify_instance_offline",
+        "notify_instance_back_online", "notify_instance_stalled",
+        "notify_instance_recovered_from_stall",
+        "notify_vip_transfer", "notify_vip_group_stalled",
+        "notify_vip_group_recovered",
+    ):
+        monkeypatch.setattr(pushover, name, _noop)
+    yield
+
+
+# ── Site / master / replica setup ────────────────────────────────────────────
+
+
+MASTER_URL = "http://master.test"
+REPLICA_URL = "http://replica.test"
+
+
+@pytest.fixture
+async def site(db_session):
+    from app.models.site import Site
+    s = Site(name="Test", slug="test", is_active=True, is_main=True)
+    db_session.add(s)
+    await db_session.commit()
+    await db_session.refresh(s)
+    return s
+
+
+@pytest.fixture
+async def cluster(db_session, site):
+    """One master + one replica with respx-friendly URLs."""
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    from app.models.pihole import PiholeInstance
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+
+    master = PiholeInstance(
+        site_id=site.id, name="master", url=MASTER_URL,
+        api_password="pw", is_master=True, is_active=True,
+    )
+    replica = PiholeInstance(
+        site_id=site.id, name="replica", url=REPLICA_URL,
+        api_password="pw", is_master=False, is_active=True,
+    )
+    db_session.add_all([master, replica])
+    await db_session.commit()
+    await db_session.refresh(master)
+    await db_session.refresh(replica)
+    return master, replica
+
+
+@pytest.fixture(autouse=True)
+async def _clear_client_registry():
+    """run_sync uses get_client → reuses a persistent PiholeClient
+    across tests. Wipe it so respx routes set up by the next test
+    aren't shadowed by the old client's open httpx instance."""
+    from app.services import client_manager
+
+    client_manager._clients.clear()
+    client_manager._last_persisted_sid.clear()
+    yield
+    for key in list(client_manager._clients):
+        try:
+            await client_manager._clients[key].close()
+        except Exception:
+            pass
+    client_manager._clients.clear()
+    client_manager._last_persisted_sid.clear()
+
+
+# ── Happy path ───────────────────────────────────────────────────────────────
+
+
+async def test_run_sync_happy_path(cluster, respx_mock):
+    """Master → 1 replica, every Pi-hole call succeeds. Final state
+    is `success` and both rows show success."""
+    from app.services.sync_service import run_sync
+
+    master, replica = cluster
+
+    # Master endpoints.
+    respx_mock.post(f"{MASTER_URL}/api/auth").respond(
+        200, json={"session": {"sid": "master-sid"}}
+    )
+    respx_mock.post(f"{MASTER_URL}/api/action/gravity").respond(200)
+    respx_mock.get(f"{MASTER_URL}/api/teleporter").respond(
+        200, content=_valid_teleporter_zip()
+    )
+
+    # Replica endpoints.
+    respx_mock.post(f"{REPLICA_URL}/api/auth").respond(
+        200, json={"session": {"sid": "replica-sid"}}
+    )
+    respx_mock.post(f"{REPLICA_URL}/api/teleporter").respond(200)
+    respx_mock.post(f"{REPLICA_URL}/api/action/gravity").respond(200)
+
+    state = await run_sync(site_id=master.site_id)
+
+    assert state.status == "success"
+    assert state.master == "master"
+    assert len(state.results) == 1
+    assert state.results[0].name == "replica"
+    assert state.results[0].status == "success"
+
+
+async def test_run_sync_records_replica_failure(cluster, respx_mock):
+    """Replica's teleporter import fails on both attempts (transient
+    + retry). Overall sync state is `error`, the replica's row is
+    flagged with the error string. Master is still reported success."""
+    from app.services.sync_service import run_sync
+
+    master, replica = cluster
+
+    respx_mock.post(f"{MASTER_URL}/api/auth").respond(
+        200, json={"session": {"sid": "master-sid"}}
+    )
+    respx_mock.post(f"{MASTER_URL}/api/action/gravity").respond(200)
+    respx_mock.get(f"{MASTER_URL}/api/teleporter").respond(
+        200, content=_valid_teleporter_zip()
+    )
+
+    respx_mock.post(f"{REPLICA_URL}/api/auth").respond(
+        200, json={"session": {"sid": "replica-sid"}}
+    )
+    # Both attempts fail with non-transient 500 — no retry path.
+    respx_mock.post(f"{REPLICA_URL}/api/teleporter").respond(500)
+
+    state = await run_sync(site_id=master.site_id)
+
+    assert state.status == "error"
+    assert len(state.results) == 1
+    assert state.results[0].status == "error"
+    assert state.results[0].error  # non-empty
+
+
+async def test_run_sync_aborts_when_master_export_fails(cluster, respx_mock):
+    """Master's teleporter endpoint is broken — sync_service retries
+    once, then surfaces a `RuntimeError` and parks the state at
+    `error`."""
+    from app.services.sync_service import run_sync
+
+    master, _ = cluster
+
+    respx_mock.post(f"{MASTER_URL}/api/auth").respond(
+        200, json={"session": {"sid": "master-sid"}}
+    )
+    respx_mock.post(f"{MASTER_URL}/api/action/gravity").respond(200)
+    # Both attempts return 500 — no usable export.
+    respx_mock.get(f"{MASTER_URL}/api/teleporter").respond(500)
+
+    state = await run_sync(site_id=master.site_id)
+    assert state.status == "error"
+    assert state.error is not None and "teleporter" in state.error.lower()
+
+
+# ── notify_blocklist_count → auto-sync ───────────────────────────────────────
+
+
+async def test_notify_blocklist_count_initial_call_is_noop(cluster, respx_mock):
+    """First observation establishes the watermark — even with auto-
+    sync enabled, no sync runs because there's nothing to compare."""
+    from app.services import sync_service
+
+    master, _ = cluster
+    sync_service._schedule_by_site[str(master.site_id)] = {
+        "interval_minutes": 0, "auto_gravity": True,
+        "import_config": True, "import_gravity": True,
+        "import_dhcp_leases": False, "run_gravity": True,
+    }
+
+    triggered = []
+
+    async def _record(**kwargs):
+        triggered.append(kwargs)
+
+    # Replace run_sync so we just record the trigger instead of doing
+    # the full orchestration here.
+    import app.services.sync_service as ss
+    original = ss.run_sync
+    ss.run_sync = _record  # type: ignore[assignment]
+    try:
+        await ss.notify_blocklist_count(master.site_id, count=1000)
+    finally:
+        ss.run_sync = original
+
+    assert triggered == []
+    assert sync_service._last_blocklist_by_site[str(master.site_id)] == 1000
+
+
+async def test_notify_blocklist_count_change_triggers_auto_sync(cluster):
+    """Second observation with a different count fires run_sync via
+    _spawn (when auto_gravity is enabled)."""
+    from app.services import sync_service
+
+    master, _ = cluster
+    sync_service._schedule_by_site[str(master.site_id)] = {
+        "interval_minutes": 0, "auto_gravity": True,
+        "import_config": True, "import_gravity": True,
+        "import_dhcp_leases": False, "run_gravity": True,
+    }
+
+    triggered = []
+
+    async def _record(**kwargs):
+        triggered.append(kwargs)
+
+    import app.services.sync_service as ss
+    original = ss.run_sync
+    ss.run_sync = _record  # type: ignore[assignment]
+    try:
+        # First call seeds the watermark.
+        await ss.notify_blocklist_count(master.site_id, count=1000)
+        assert triggered == []
+        # Second call with a different count fires auto-sync.
+        await ss.notify_blocklist_count(master.site_id, count=1100)
+        # _spawn schedules a task; let the loop run it.
+        import asyncio
+        await asyncio.sleep(0.05)
+    finally:
+        ss.run_sync = original
+
+    assert len(triggered) == 1
+    assert triggered[0]["site_id"] == master.site_id
+
+
+async def test_notify_blocklist_count_no_auto_sync_when_disabled(cluster):
+    """With auto_gravity=False, even a count change must not trigger
+    a sync — the blocklist watermark is still updated for next time."""
+    from app.services import sync_service
+
+    master, _ = cluster
+    sync_service._schedule_by_site[str(master.site_id)] = {
+        "interval_minutes": 0, "auto_gravity": False,
+        "import_config": True, "import_gravity": True,
+        "import_dhcp_leases": False, "run_gravity": True,
+    }
+
+    triggered = []
+
+    async def _record(**kwargs):
+        triggered.append(kwargs)
+
+    import app.services.sync_service as ss
+    original = ss.run_sync
+    ss.run_sync = _record  # type: ignore[assignment]
+    try:
+        await ss.notify_blocklist_count(master.site_id, count=1000)
+        await ss.notify_blocklist_count(master.site_id, count=1100)
+    finally:
+        ss.run_sync = original
+
+    assert triggered == []

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -5,3 +5,38 @@ The session-scoped event loop set in pytest.ini still applies, so async
 fixtures don't see cross-loop issues.
 """
 from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_collector_state():
+    """The collector module keeps per-instance + per-site state in
+    bare module-level dicts. Clear them between tests so a circuit-
+    breaker trip in one case can't poison a fresh-state assertion in
+    the next."""
+    from app.services import collector
+
+    state_dicts = (
+        collector._consec_failures,
+        collector._cooldown_until,
+        collector._last_failure_at,
+        collector._last_seen_ts,
+        collector._prev_status,
+        collector._offline_retry_count,
+        collector._offline_alert_count,
+        collector._stall_count,
+        collector._stall_alerted,
+        collector._prev_dns_queries_today,
+        collector._prev_watermark_for_stall,
+        collector._vip_last_advance_seq,
+        collector._vip_advance_streak,
+        collector._vip_active_node,
+        collector._vip_group_stall_alerted,
+        collector._site_poll_seq,
+    )
+    for d in state_dicts:
+        d.clear()
+    yield
+    for d in state_dicts:
+        d.clear()

--- a/tests/services/test_collector_state.py
+++ b/tests/services/test_collector_state.py
@@ -1,0 +1,332 @@
+"""Tests for the per-instance + per-site state machines that drive
+collector.py.
+
+These functions are technically not pure (they read/write module-level
+dicts) but they don't touch the DB or the network, so they go in the
+fast service-layer suite. The autouse `_reset_collector_state` fixture
+in conftest.py clears every dict between tests.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services import collector
+from app.models.pihole import StatsSnapshot
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+class _StubInstance:
+    """Stand-in for app.models.pihole.PiholeInstance — only the attrs
+    that the state-machine helpers read."""
+
+    def __init__(
+        self,
+        instance_id: uuid.UUID | None = None,
+        name: str = "p1",
+        vip_role: str | None = None,
+        site_id: uuid.UUID | None = None,
+    ):
+        self.id = instance_id or uuid.uuid4()
+        self.name = name
+        self.vip_role = vip_role
+        self.site_id = site_id or uuid.uuid4()
+
+
+def _snap(count: int = 0, status: str = "online") -> StatsSnapshot:
+    return StatsSnapshot(
+        instance_id=uuid.uuid4(),
+        collected_at=datetime.now(timezone.utc),
+        status=status,
+        dns_queries_today=count,
+    )
+
+
+# ── Circuit breaker ──────────────────────────────────────────────────────────
+
+
+def test_breaker_allows_when_no_cooldown():
+    assert collector._breaker_allows("k", "name") is True
+
+
+def test_breaker_blocks_during_active_cooldown():
+    collector._cooldown_until["k"] = datetime.now(timezone.utc) + timedelta(seconds=300)
+    assert collector._breaker_allows("k", "name") is False
+
+
+def test_breaker_allows_after_cooldown_expires():
+    collector._cooldown_until["k"] = datetime.now(timezone.utc) - timedelta(seconds=1)
+    assert collector._breaker_allows("k", "name") is True
+
+
+def test_breaker_failure_increments_then_trips_at_threshold():
+    """N consecutive failures past the threshold open the breaker."""
+    threshold = collector._CIRCUIT_FAIL_THRESHOLD
+    # Push _last_failure_at backwards each iteration so the dedup window
+    # doesn't swallow the increments.
+    for _ in range(threshold):
+        # Force the dedup check to "old enough" before each failure call.
+        collector._last_failure_at["k"] = time.monotonic() - 10
+        collector._breaker_failure("k", "name")
+    # After threshold consecutive failures, cooldown is armed.
+    assert "k" in collector._cooldown_until
+
+
+def test_breaker_failure_dedups_within_window():
+    """Stats + queries polls share the same TCP connection, so a single
+    network blip surfaces as two simultaneous failures. The dedup
+    window collapses them so the breaker doesn't trip on the first
+    real hiccup."""
+    collector._breaker_failure("k", "name")
+    first_count = collector._consec_failures["k"]
+    # Immediately call again — within dedup window, must NOT increment.
+    collector._breaker_failure("k", "name")
+    assert collector._consec_failures["k"] == first_count
+
+
+def test_breaker_success_clears_all_state():
+    collector._consec_failures["k"] = 2
+    collector._cooldown_until["k"] = datetime.now(timezone.utc) + timedelta(seconds=300)
+    collector._last_failure_at["k"] = time.monotonic()
+
+    collector._breaker_success("k", "name")
+
+    assert "k" not in collector._consec_failures
+    assert "k" not in collector._cooldown_until
+    assert "k" not in collector._last_failure_at
+
+
+# ── _instance_advanced ───────────────────────────────────────────────────────
+
+
+def test_instance_advanced_returns_none_on_first_poll():
+    """No prior baseline means we can't tell — return None so the
+    stall detector treats it as a bootstrap poll."""
+    inst = _StubInstance()
+    snap = _snap(count=100)
+    result = collector._instance_advanced(inst, snap)
+    assert result is None
+
+
+def test_instance_advanced_returns_true_when_counter_grew():
+    inst = _StubInstance()
+    collector._instance_advanced(inst, _snap(count=100))  # establish baseline
+    result = collector._instance_advanced(inst, _snap(count=110))
+    assert result is True
+
+
+def test_instance_advanced_returns_false_when_flat():
+    inst = _StubInstance()
+    collector._instance_advanced(inst, _snap(count=100))  # baseline
+    result = collector._instance_advanced(inst, _snap(count=100))  # no change
+    assert result is False
+
+
+def test_instance_advanced_treats_counter_rollover_as_reset():
+    """At midnight, dns_queries_today rolls back to 0. That's not a
+    stall — clear pending stall state and return False."""
+    inst = _StubInstance()
+    collector._instance_advanced(inst, _snap(count=100_000))  # busy day
+    collector._stall_count[str(inst.id)] = 3  # in-flight stall counter
+    collector._stall_alerted[str(inst.id)] = True
+
+    result = collector._instance_advanced(inst, _snap(count=50))  # rollover
+    assert result is False
+    assert str(inst.id) not in collector._stall_count
+    assert str(inst.id) not in collector._stall_alerted
+
+
+def test_instance_advanced_uses_watermark_when_counter_flat():
+    """A flat dns_queries_today + a moved query watermark still counts
+    as advancement — the instance is processing traffic."""
+    inst = _StubInstance()
+    collector._last_seen_ts[str(inst.id)] = 1000.0
+    collector._instance_advanced(inst, _snap(count=100))  # baseline
+
+    # Counter unchanged but watermark moved forward.
+    collector._last_seen_ts[str(inst.id)] = 2000.0
+    result = collector._instance_advanced(inst, _snap(count=100))
+    assert result is True
+
+
+# ── _check_stalled ───────────────────────────────────────────────────────────
+
+
+def test_check_stalled_skips_vip_instances():
+    """Stall detection for VIP-grouped instances is handled by
+    _check_vip_state instead — per-instance check would false-fire on
+    legitimately-idle standbys."""
+    inst = _StubInstance(vip_role="replica")
+    collector._check_stalled(inst, advanced=False, site_name="test")
+    assert str(inst.id) not in collector._stall_count
+
+
+def test_check_stalled_skips_bootstrap_poll():
+    inst = _StubInstance()
+    collector._check_stalled(inst, advanced=None, site_name="test")
+    assert str(inst.id) not in collector._stall_count
+
+
+def test_check_stalled_increments_then_alerts(monkeypatch):
+    """After _STALL_THRESHOLD_POLLS consecutive flat polls, the alert
+    fires exactly once (via _spawn → pushover)."""
+    spawned = []
+    monkeypatch.setattr(collector, "_spawn", lambda coro: spawned.append(coro))
+
+    inst = _StubInstance()
+    threshold = collector._STALL_THRESHOLD_POLLS
+
+    for i in range(threshold - 1):
+        collector._check_stalled(inst, advanced=False, site_name="test")
+        assert str(inst.id) not in collector._stall_alerted, (
+            f"alerted too early at poll {i + 1}/{threshold}"
+        )
+
+    # Threshold-th flat poll triggers the alert.
+    collector._check_stalled(inst, advanced=False, site_name="test")
+    assert collector._stall_alerted[str(inst.id)] is True
+    assert len(spawned) == 1
+
+    # Close the unawaited coroutines so pytest doesn't warn.
+    for c in spawned:
+        c.close()
+
+
+# ── _check_vip_state ─────────────────────────────────────────────────────────
+
+
+async def test_vip_transfer_requires_5_confirming_polls(monkeypatch):
+    """A standby that briefly serves a few queries must NOT trigger a
+    transfer alert — only sustained advancement past the confirm
+    threshold counts. Replaces the dev.20-era 2-poll false-positive
+    bug."""
+    spawned = []
+    monkeypatch.setattr(collector, "_spawn", lambda coro: spawned.append(coro))
+
+    site_id = uuid.uuid4()
+    master = _StubInstance(name="m", vip_role="master", site_id=site_id)
+    replica = _StubInstance(name="r", vip_role="replica", site_id=site_id)
+
+    # Bootstrap: master is the active node.
+    outcomes = [
+        (master, _snap(), True),    # master advances → seeds active
+        (replica, _snap(), False),
+    ]
+    await collector._check_vip_state(site_id, "site", outcomes, configured_vip_count=2)
+    assert collector._vip_active_node[site_id] == master.id
+
+    # Now master goes idle, replica advances — but only 4 polls in a
+    # row, one short of the confirmation threshold.
+    confirm = collector._VIP_TRANSFER_CONFIRM_POLLS
+    for _ in range(confirm - 1):
+        outcomes = [
+            (master, _snap(), False),
+            (replica, _snap(), True),
+        ]
+        await collector._check_vip_state(site_id, "site", outcomes, configured_vip_count=2)
+
+    # Active node has not transferred yet.
+    assert collector._vip_active_node[site_id] == master.id
+    transfer_calls = [c for c in spawned]
+    for c in transfer_calls:
+        c.close()
+    assert len(transfer_calls) == 0
+
+
+async def test_vip_transfer_fires_after_confirm_threshold(monkeypatch):
+    spawned: list = []
+    monkeypatch.setattr(collector, "_spawn", lambda coro: spawned.append(coro))
+
+    site_id = uuid.uuid4()
+    master = _StubInstance(name="m", vip_role="master", site_id=site_id)
+    replica = _StubInstance(name="r", vip_role="replica", site_id=site_id)
+
+    # Seed master as active.
+    await collector._check_vip_state(
+        site_id, "site",
+        [(master, _snap(), True), (replica, _snap(), False)],
+        configured_vip_count=2,
+    )
+
+    confirm = collector._VIP_TRANSFER_CONFIRM_POLLS
+    for _ in range(confirm):
+        outcomes = [
+            (master, _snap(), False),
+            (replica, _snap(), True),
+        ]
+        await collector._check_vip_state(site_id, "site", outcomes, configured_vip_count=2)
+
+    assert collector._vip_active_node[site_id] == replica.id
+    assert len(spawned) >= 1
+    for c in spawned:
+        c.close()
+
+
+async def test_vip_group_stall_requires_every_node_observed_online(monkeypatch):
+    """1.11.0-dev.20 fix: group-stall must NOT fire when one VIP node
+    is offline (excluded from poll_outcomes). Treating a missing node
+    as 'flat' produced false positives during transient master TLS
+    blips. Per-instance offline alerts cover real outages."""
+    spawned: list = []
+    monkeypatch.setattr(collector, "_spawn", lambda coro: spawned.append(coro))
+
+    site_id = uuid.uuid4()
+    master = _StubInstance(name="m", vip_role="master", site_id=site_id)
+    replica = _StubInstance(name="r", vip_role="replica", site_id=site_id)
+
+    # Both nodes advance once so `ever_advanced` becomes True (group
+    # stall can only fire on a cluster that has historical activity).
+    await collector._check_vip_state(
+        site_id, "site",
+        [(master, _snap(), True), (replica, _snap(), True)],
+        configured_vip_count=2,
+    )
+
+    # Now report only ONE node — simulating the master being offline
+    # and dropped from poll_outcomes. configured_vip_count stays at 2.
+    threshold = collector._STALL_THRESHOLD_POLLS
+    for _ in range(threshold + 2):
+        await collector._check_vip_state(
+            site_id, "site",
+            [(replica, _snap(), False)],  # only replica observed
+            configured_vip_count=2,
+        )
+
+    # Group-stall must NOT have fired — too few nodes observed.
+    assert collector._vip_group_stall_alerted.get(site_id, False) is False
+    for c in spawned:
+        c.close()
+
+
+async def test_vip_group_stall_fires_when_all_nodes_flat(monkeypatch):
+    spawned: list = []
+    monkeypatch.setattr(collector, "_spawn", lambda coro: spawned.append(coro))
+
+    site_id = uuid.uuid4()
+    master = _StubInstance(name="m", vip_role="master", site_id=site_id)
+    replica = _StubInstance(name="r", vip_role="replica", site_id=site_id)
+
+    # Establish baseline activity (so `ever_advanced` is True).
+    await collector._check_vip_state(
+        site_id, "site",
+        [(master, _snap(), True), (replica, _snap(), True)],
+        configured_vip_count=2,
+    )
+
+    # Now both nodes go flat for the threshold-many polls.
+    threshold = collector._STALL_THRESHOLD_POLLS
+    for _ in range(threshold + 1):
+        await collector._check_vip_state(
+            site_id, "site",
+            [(master, _snap(), False), (replica, _snap(), False)],
+            configured_vip_count=2,
+        )
+
+    assert collector._vip_group_stall_alerted[site_id] is True
+    for c in spawned:
+        c.close()


### PR DESCRIPTION
## Summary
PR 4 of 6 — the heaviest. Covers the state machines that drive every alert MyPi fires (circuit breaker, stall detection, VIP transfer, group stall) and the run_sync orchestration that has historically been the source of master/replica drift incidents.

## What lands
- **\`tests/services/test_collector_state.py\` (15 tests)**
  - Circuit breaker: 6 cases including the dedup-window collapse for stats+queries failures sharing one connection, threshold trip, success-resets-all
  - _instance_advanced: 5 cases — bootstrap None, counter growth, flat, **midnight rollover treated as reset (clears stall state)**, watermark-only advance
  - _check_stalled: VIP-skip, bootstrap-skip, threshold-fires-once
  - _check_vip_state: 4 VIP regression guards — **transfer requires 5 confirming polls** (regression-guards the dev.20 false-positive bug), **group stall requires every configured node observed online** (dev.20 fix), positive group-stall fire path

- **\`tests/integration/test_collector.py\` (3 tests)**
  - prune_inactive_state drops state for deactivated instances + keeps state for active
  - cleanup_old_data wipes rows past DATA_RETENTION_DAYS across StatsSnapshot, QueryLog, RevokedToken

- **\`tests/integration/test_sync_service.py\` (6 tests)**
  - **run_sync happy path** (master gravity → export → broadcast → replica gravity)
  - **Replica failure recorded** with error string, overall sync = error
  - **Master export failure aborts sync** with state.error populated
  - notify_blocklist_count: initial seeds watermark, change triggers auto-sync, no-op when auto_gravity=False

## Wave-callouts
- The dev.20 VIP fixes have **regression guards** now: any future change that loosens the 5-poll confirmation or treats missing-from-poll-outcomes as \"flat\" will fail tests.
- The midnight-rollover edge case in _instance_advanced is now locked down — without the test, a refactor that drops the \`new_count < prev_count\` branch would silently start firing stall alerts at midnight on every busy instance.

## Local results
\`\`\`
$ ./scripts/test.sh
============================= 177 passed in 24.31s =============================
\`\`\`

## What's next (PRs 5–6)
- PR 5: remaining API surface (sites, instances, queries, sync API, notifications, version, display) + Pushover encrypt/decrypt + version_check
- PR 6: E2E bash smoke + ratchet coverage gate + close out the test-suite initiative

🤖 Generated with [Claude Code](https://claude.com/claude-code)