### PR TITLE
API surface + service-layer tests (PR 5/6)

### DIFF
--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -1,0 +1,21 @@
+"""Tests for the unauthenticated /api/health endpoint."""
+from __future__ import annotations
+
+
+async def test_health_returns_200_unauthenticated(client):
+    """The iOS app calls /api/health before its API key is configured —
+    the endpoint must work without any auth header."""
+    resp = await client.get("/api/health")
+    assert resp.status_code == 200
+
+
+async def test_health_returns_version_and_intervals(client):
+    """Response shape is part of the iOS app's contract — it reads
+    `stats_poll_interval` to compute staleness thresholds."""
+    resp = await client.get("/api/health")
+    body = resp.json()
+    assert "version" in body
+    assert "stats_poll_interval" in body
+    assert "queries_poll_interval" in body
+    assert isinstance(body["stats_poll_interval"], int)
+    assert isinstance(body["queries_poll_interval"], int)

--- a/tests/integration/test_notifications_api.py
+++ b/tests/integration/test_notifications_api.py
@@ -1,0 +1,121 @@
+"""Tests for /api/notifications — Pushover settings round-trip,
+mask-on-read, validate, test endpoint rate-limited."""
+from __future__ import annotations
+
+import pytest
+import respx
+
+
+@pytest.fixture
+async def site(db_session):
+    """Pushover settings persist into site_settings under the Main
+    site, so we need at least one Site row for save_settings to work."""
+    from app.models.site import Site
+    s = Site(name="Main", slug="main", is_main=True, is_active=True, sort_order=0)
+    db_session.add(s)
+    await db_session.commit()
+    await db_session.refresh(s)
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _reset_pushover_module(monkeypatch):
+    """Pushover settings live in module globals — reset between tests
+    so a save in one doesn't leak into another."""
+    from app.services import pushover
+    monkeypatch.setattr(pushover, "_app_token", "")
+    monkeypatch.setattr(pushover, "_user_key", "")
+    monkeypatch.setattr(pushover, "_enabled", False)
+    yield
+
+
+async def test_get_settings_unauthenticated_returns_401(client):
+    resp = await client.get("/api/notifications/settings")
+    assert resp.status_code == 401
+
+
+async def test_save_and_get_settings_round_trip(authed_client, site):
+    payload = {
+        "app_token": "azGDORePK8gMaC0QOYAMyEEuzJnyUi",
+        "user_key": "uQiRzpo4DXghDmr9QzzfQu27cmVRsG",
+        "enabled": True,
+        "alert_sync_failure": True,
+        "alert_instance_offline": True,
+        "alert_high_block_rate": False,
+        "alert_on_vip_transfer": False,
+        "block_rate_threshold_pct": 50.0,
+        "offline_alert_max_count": 1,
+        "offline_alert_retries": 1,
+    }
+    put = await authed_client.put("/api/notifications/settings", json=payload)
+    assert put.status_code == 200
+    body = put.json()
+    # GET response masks the sensitive bits — only the last 4 chars survive.
+    assert body["app_token"].startswith("****")
+    assert body["app_token"].endswith(payload["app_token"][-4:])
+    assert body["user_key"].startswith("****")
+
+
+async def test_get_settings_masks_credentials(authed_client, site):
+    """After save, retrieving the settings returns masked tokens — the
+    raw credentials never leak via the API."""
+    raw_token = "abcdef0123456789abcdef0123456789"
+    raw_key = "0123456789abcdef0123456789abcdef"
+    await authed_client.put("/api/notifications/settings", json={
+        "app_token": raw_token, "user_key": raw_key, "enabled": True,
+        "alert_sync_failure": True, "alert_instance_offline": True,
+        "alert_high_block_rate": False, "alert_on_vip_transfer": False,
+        "block_rate_threshold_pct": 50.0,
+        "offline_alert_max_count": 1, "offline_alert_retries": 1,
+    })
+    resp = await authed_client.get("/api/notifications/settings")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert raw_token not in body["app_token"]
+    assert raw_key not in body["user_key"]
+    # Last 4 chars survive for operator recognition.
+    assert body["app_token"].endswith(raw_token[-4:])
+
+
+async def test_validate_endpoint_calls_pushover(authed_client, respx_mock):
+    """Validate POSTs to api.pushover.net/users/validate.json and
+    returns whether the credentials were accepted."""
+    respx_mock.post("https://api.pushover.net/1/users/validate.json").respond(
+        200, json={"status": 1}
+    )
+    resp = await authed_client.post(
+        "/api/notifications/validate",
+        json={"app_token": "tok", "user_key": "key"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+async def test_validate_endpoint_reports_failure(authed_client, respx_mock):
+    respx_mock.post("https://api.pushover.net/1/users/validate.json").respond(
+        200, json={"status": 0, "errors": ["application token is invalid"]}
+    )
+    resp = await authed_client.post(
+        "/api/notifications/validate",
+        json={"app_token": "tok", "user_key": "key"},
+    )
+    body = resp.json()
+    assert body["ok"] is False
+    assert "invalid" in body["error"].lower()
+
+
+async def test_save_settings_blocked_on_readonly_key(
+    client, readonly_api_key, site,
+):
+    resp = await client.put(
+        "/api/notifications/settings",
+        headers={"X-API-Key": readonly_api_key},
+        json={
+            "app_token": "x", "user_key": "y", "enabled": True,
+            "alert_sync_failure": True, "alert_instance_offline": True,
+            "alert_high_block_rate": False, "alert_on_vip_transfer": False,
+            "block_rate_threshold_pct": 50.0,
+            "offline_alert_max_count": 1, "offline_alert_retries": 1,
+        },
+    )
+    assert resp.status_code == 403

--- a/tests/integration/test_pushover_service.py
+++ b/tests/integration/test_pushover_service.py
@@ -1,0 +1,134 @@
+"""Tests for app/services/pushover.py — the encrypt/decrypt round-trip
+that protects creds at rest, the masking helper, and alert filtering."""
+from __future__ import annotations
+
+import json
+
+import pytest
+from cryptography.fernet import Fernet
+
+
+@pytest.fixture(autouse=True)
+def _ensure_fernet_key():
+    """Fernet encryption needs an active key — ensure one exists before
+    any encrypt/decrypt call."""
+    from app.config import settings
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_pushover_module(monkeypatch):
+    from app.services import pushover
+    monkeypatch.setattr(pushover, "_app_token", "")
+    monkeypatch.setattr(pushover, "_user_key", "")
+    monkeypatch.setattr(pushover, "_enabled", False)
+    yield
+
+
+# ── Encrypt / decrypt round-trip ─────────────────────────────────────────────
+
+
+def test_encrypt_then_decrypt_recovers_plaintext():
+    from app.services.pushover import _decrypt, _encrypt
+    plaintext = "azGDORePK8gMaC0QOYAMyEEuzJnyUi"
+    cipher = _encrypt(plaintext)
+    assert cipher != plaintext  # ciphertext should differ
+    assert _decrypt(cipher) == plaintext
+
+
+def test_encrypt_passes_empty_through():
+    """Empty values short-circuit so we never store an empty Fernet
+    token (which would still be valid bytes but pointless)."""
+    from app.services.pushover import _encrypt
+    assert _encrypt("") == ""
+
+
+def test_decrypt_treats_legacy_plaintext_as_passthrough():
+    """Settings written before encryption was added are stored as
+    plain text. _decrypt returns them as-is so the next save_settings
+    re-encrypts them — the migration is silent."""
+    from app.services.pushover import _decrypt
+    legacy = "this-is-plaintext-not-fernet"
+    assert _decrypt(legacy) == legacy
+
+
+# ── Mask helper ──────────────────────────────────────────────────────────────
+
+
+def test_mask_returns_last_4_chars():
+    from app.services.pushover import _mask
+    assert _mask("0123456789abcdef") == "****cdef"
+
+
+def test_mask_returns_empty_for_unset():
+    from app.services.pushover import _mask
+    assert _mask("") == ""
+
+
+# ── Alert filtering ──────────────────────────────────────────────────────────
+
+
+async def test_send_returns_false_when_not_enabled():
+    """Even with valid credentials in memory, send() short-circuits
+    if `enabled` is False — guards against accidentally pushing alerts
+    while a feature flag is off."""
+    from app.services import pushover
+    pushover._app_token = "tok"
+    pushover._user_key = "key"
+    pushover._enabled = False
+    assert await pushover.send("body") is False
+
+
+async def test_send_returns_false_when_credentials_missing():
+    from app.services import pushover
+    pushover._app_token = ""
+    pushover._user_key = ""
+    pushover._enabled = True
+    assert await pushover.send("body") is False
+
+
+async def test_notify_sync_failure_skipped_when_alert_disabled(monkeypatch):
+    """notify_sync_failure honours the `alert_sync_failure` toggle and
+    returns without contacting Pushover."""
+    from app.services import pushover
+
+    pushover._enabled = True
+    pushover._app_token = "tok"
+    pushover._user_key = "key"
+    monkeypatch.setattr(pushover, "_alert_sync_failure", False)
+
+    sent = []
+
+    async def _capture(*args, **kwargs):
+        sent.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr(pushover, "send", _capture)
+    await pushover.notify_sync_failure("boom")
+
+    assert sent == []
+
+
+async def test_notify_sync_failure_sends_when_enabled(monkeypatch):
+    from app.services import pushover
+
+    pushover._enabled = True
+    pushover._app_token = "tok"
+    pushover._user_key = "key"
+    monkeypatch.setattr(pushover, "_alert_sync_failure", True)
+
+    sent = []
+
+    async def _capture(*args, **kwargs):
+        sent.append(kwargs.get("title"))
+        return True
+
+    monkeypatch.setattr(pushover, "send", _capture)
+    await pushover.notify_sync_failure("boom")
+
+    assert "MyPi Sync Error" in sent

--- a/tests/integration/test_sites_api.py
+++ b/tests/integration/test_sites_api.py
@@ -1,0 +1,132 @@
+"""Tests for /api/sites — list, per-slug resolve, slug-history redirects."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+async def two_sites(db_session):
+    from app.models.site import Site
+    main = Site(name="Main", slug="main-site", is_main=True, is_active=True, sort_order=0)
+    other = Site(name="Other", slug="other", is_main=False, is_active=True, sort_order=1)
+    db_session.add_all([main, other])
+    await db_session.commit()
+    await db_session.refresh(main)
+    await db_session.refresh(other)
+    return main, other
+
+
+async def test_list_sites_requires_auth(client, two_sites):
+    """No cookie, no API key → 401."""
+    resp = await client.get("/api/sites")
+    assert resp.status_code == 401
+
+
+async def test_list_sites_returns_active_only(authed_client, db_session, two_sites):
+    from app.models.site import Site
+
+    # Add a deactivated site that should NOT appear in the list.
+    inactive = Site(
+        name="Old", slug="orphan", is_main=False, is_active=False, sort_order=99,
+    )
+    db_session.add(inactive)
+    await db_session.commit()
+
+    resp = await authed_client.get("/api/sites")
+    assert resp.status_code == 200
+    body = resp.json()
+    slugs = {s["slug"] for s in body}
+    assert "main-site" in slugs
+    assert "other" in slugs
+    assert "orphan" not in slugs
+
+
+async def test_list_sites_returns_instance_counts(authed_client, db_session, two_sites):
+    """Each row carries instance_count + active_instance_count so the UI
+    can show counts without a per-row API roundtrip."""
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    from app.models.pihole import PiholeInstance
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+
+    main, _ = two_sites
+    db_session.add_all([
+        PiholeInstance(
+            site_id=main.id, name="active1", url="http://x1",
+            api_password="p", is_active=True,
+        ),
+        PiholeInstance(
+            site_id=main.id, name="inactive1", url="http://x2",
+            api_password="p", is_active=False,
+        ),
+    ])
+    await db_session.commit()
+
+    resp = await authed_client.get("/api/sites")
+    body = resp.json()
+    main_row = next(s for s in body if s["slug"] == "main-site")
+    assert main_row["instance_count"] == 2
+    assert main_row["active_instance_count"] == 1
+
+
+async def test_get_site_by_slug(authed_client, two_sites):
+    resp = await authed_client.get("/api/sites/main-site")
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "main-site"
+    assert resp.json()["is_main"] is True
+
+
+async def test_get_site_unknown_slug_returns_404(authed_client):
+    resp = await authed_client.get("/api/sites/nope-not-a-site")
+    assert resp.status_code == 404
+
+
+async def test_inactive_site_endpoint_returns_orphans(
+    authed_client, db_session, two_sites,
+):
+    from app.models.site import Site
+    db_session.add(Site(
+        name="Removed", slug="removed", is_main=False,
+        is_active=False, sort_order=99,
+    ))
+    await db_session.commit()
+
+    resp = await authed_client.get("/api/sites/inactive")
+    assert resp.status_code == 200
+    slugs = {s["slug"] for s in resp.json()}
+    assert "removed" in slugs
+    # Active sites must NOT appear here.
+    assert "main-site" not in slugs
+
+
+async def test_delete_active_site_returns_409(authed_client, two_sites):
+    """Active sites must be removed from pihole_instances.yml first."""
+    resp = await authed_client.delete("/api/sites/main-site")
+    assert resp.status_code == 409
+
+
+async def test_delete_orphan_site_succeeds(authed_client, db_session, two_sites):
+    from app.models.site import Site
+    from sqlalchemy import select
+
+    db_session.add(Site(
+        name="Old", slug="old-orphan", is_main=False, is_active=False,
+        sort_order=99,
+    ))
+    await db_session.commit()
+
+    resp = await authed_client.delete("/api/sites/old-orphan")
+    assert resp.status_code == 204
+
+    from app.database import AsyncSessionLocal
+    async with AsyncSessionLocal() as fresh:
+        survivor = (
+            await fresh.execute(select(Site).where(Site.slug == "old-orphan"))
+        ).scalar_one_or_none()
+    assert survivor is None

--- a/tests/integration/test_sync_api.py
+++ b/tests/integration/test_sync_api.py
@@ -1,0 +1,90 @@
+"""Tests for the /api/sync endpoints — status, schedule round-trip,
+trigger validation."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+async def site(db_session):
+    from app.models.site import Site
+    s = Site(name="Main", slug="main", is_main=True, is_active=True, sort_order=0)
+    db_session.add(s)
+    await db_session.commit()
+    await db_session.refresh(s)
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _reset_sync_state():
+    from app.services import sync_service
+    sync_service._state_by_site.clear()
+    sync_service._lock_by_site.clear()
+    sync_service._schedule_by_site.clear()
+    yield
+
+
+async def test_sync_status_default_is_idle(authed_client, site):
+    resp = await authed_client.get("/api/sync/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "idle"
+    assert body["results"] == []
+
+
+async def test_sync_schedule_round_trip(authed_client, site):
+    """PUT then GET must return the same payload — settings persist
+    via site_settings."""
+    payload = {
+        "interval_minutes": 30,
+        "auto_gravity": True,
+        "import_config": True,
+        "import_gravity": True,
+        "import_dhcp_leases": False,
+        "run_gravity": True,
+    }
+    put = await authed_client.put("/api/sync/schedule", json=payload)
+    assert put.status_code == 200
+
+    got = await authed_client.get("/api/sync/schedule")
+    assert got.status_code == 200
+    body = got.json()
+    assert body["interval_minutes"] == 30
+    assert body["auto_gravity"] is True
+
+
+async def test_sync_status_unauthenticated_returns_401(client):
+    resp = await client.get("/api/sync/status")
+    assert resp.status_code == 401
+
+
+async def test_sync_schedule_put_blocked_on_readonly_key(
+    client, readonly_api_key, site,
+):
+    """Read-only API key must NOT mutate the schedule."""
+    resp = await client.put(
+        "/api/sync/schedule",
+        headers={"X-API-Key": readonly_api_key},
+        json={
+            "interval_minutes": 60, "auto_gravity": False,
+            "import_config": True, "import_gravity": True,
+            "import_dhcp_leases": False, "run_gravity": True,
+        },
+    )
+    assert resp.status_code == 403
+
+
+async def test_sync_trigger_when_already_running_returns_409(
+    authed_client, site,
+):
+    from app.services import sync_service
+
+    # Mark the site's sync as already in progress.
+    state = sync_service._get_state_dict(site.id)
+    state.status = "running"
+
+    resp = await authed_client.post("/api/sync", json={
+        "import_config": True, "import_gravity": True,
+        "import_dhcp_leases": False, "run_gravity": True,
+    })
+    assert resp.status_code == 409

--- a/tests/integration/test_version_check.py
+++ b/tests/integration/test_version_check.py
@@ -1,0 +1,85 @@
+"""Tests for app/services/version_check.py — the hourly GitHub poll
+that surfaces "update available" in the UI."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_module(monkeypatch):
+    from app.services import version_check
+    monkeypatch.setattr(version_check, "_enabled", True)
+    monkeypatch.setattr(version_check, "_current_version", "")
+    monkeypatch.setattr(version_check, "_latest_version", "")
+    monkeypatch.setattr(version_check, "_checked_at", None)
+    monkeypatch.setattr(version_check, "_check_in_progress", False)
+    yield
+
+
+async def test_initialize_records_running_version():
+    from app.services import version_check
+    version_check.initialize("2.0.5")
+    status = version_check.get_status()
+    assert status["current_version"] == "2.0.5"
+
+
+async def test_check_now_fetches_latest_from_github(respx_mock):
+    """check_now hits the raw VERSION file on GitHub and stores the
+    string in module state."""
+    from app.services import version_check
+
+    respx_mock.get(
+        "https://raw.githubusercontent.com/theojamesvibes/mypi/main/VERSION"
+    ).respond(200, text="2.1.0\n")
+
+    version_check.initialize("2.0.5")
+    await version_check.check_now()
+
+    status = version_check.get_status()
+    assert status["latest_version"] == "2.1.0"
+    assert status["up_to_date"] is False
+    assert status["checked_at"] is not None
+
+
+async def test_check_now_marks_up_to_date_when_versions_match(respx_mock):
+    from app.services import version_check
+
+    respx_mock.get(
+        "https://raw.githubusercontent.com/theojamesvibes/mypi/main/VERSION"
+    ).respond(200, text="2.0.5\n")
+
+    version_check.initialize("2.0.5")
+    await version_check.check_now()
+
+    assert version_check.get_status()["up_to_date"] is True
+
+
+async def test_check_now_skipped_when_disabled(respx_mock):
+    from app.services import version_check
+
+    route = respx_mock.get(
+        "https://raw.githubusercontent.com/theojamesvibes/mypi/main/VERSION"
+    ).respond(200, text="2.1.0\n")
+
+    version_check._enabled = False
+    version_check.initialize("2.0.5")
+    await version_check.check_now()
+
+    # No HTTP request was made — the disabled flag short-circuits.
+    assert route.call_count == 0
+
+
+async def test_check_now_handles_github_failure_silently(respx_mock):
+    """A 500 from raw.githubusercontent doesn't crash MyPi — the
+    failure is logged and the next hourly tick will retry."""
+    from app.services import version_check
+
+    respx_mock.get(
+        "https://raw.githubusercontent.com/theojamesvibes/mypi/main/VERSION"
+    ).respond(500)
+
+    version_check.initialize("2.0.5")
+    # Must not raise.
+    await version_check.check_now()
+    # latest_version stays empty since the call didn't succeed.
+    assert version_check.get_status()["latest_version"] == ""


### PR DESCRIPTION
## Summary
PR 5 of 6. Covers the remaining endpoints and services so every public surface in MyPi has at least one regression guard. Specifically lights up the API paths and service helpers that the auth / collector / sync_service tests didn't reach.

## What lands
- **\`tests/integration/test_health.py\`** (2) — unauth /api/health 200 + iOS-app contract shape
- **\`tests/integration/test_sites_api.py\`** (8) — list filtering, instance_count rollups, /api/sites/{slug} resolve + 404, /api/sites/inactive, DELETE refuses active / succeeds on orphan
- **\`tests/integration/test_sync_api.py\`** (5) — status idle, schedule round-trip, unauth 401, read-only 403, trigger-while-running 409
- **\`tests/integration/test_notifications_api.py\`** (6) — Pushover settings round-trip with **masked-on-read** (raw tokens never leak), validate endpoint hits Pushover via respx, read-only 403 on save
- **\`tests/integration/test_pushover_service.py\`** (10) — Fernet encrypt/decrypt round-trip, **legacy-plaintext passthrough** for the silent migration path, mask helper, send-when-disabled short-circuit, alert-toggle honoured for notify_sync_failure
- **\`tests/integration/test_version_check.py\`** (5) — check_now via respx, up_to_date flag, disabled-flag short-circuit, GitHub-failure-doesn't-crash

## Local results
\`\`\`
$ ./scripts/test.sh
============================= 212 passed in 30.82s =============================
\`\`\`

## What's left (PR 6)
- E2E bash smoke script that hits a running container (login, /api/health, /api/instances)
- Coverage gate: ratchet pytest-cov threshold once a baseline is established
- Close out the test-suite initiative

## Risk profile
Pure additive. CI runtime grew ~6s (212 tests vs 177).

🤖 Generated with [Claude Code](https://claude.com/claude-code)