### PR TITLE
Test coverage 62% → 76%: main.py, config_loader, API surface, services

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run pytest with coverage gate
-        run: pytest -v --cov=app --cov-report=term --cov-fail-under=60
+        run: pytest -v --cov=app --cov-report=term --cov-fail-under=75

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,9 +19,10 @@ psycopg[binary]==3.2.13
 # `respx_mock` fixture context.
 respx==0.22.0
 
-# Coverage measurement + gate. CI runs `pytest --cov=app --cov-fail-under=60`
+# Coverage measurement + gate. CI runs `pytest --cov=app --cov-fail-under=75`
 # so a PR that regresses coverage below the floor fails the build.
-# 60% floor was set after the collector polling deep-dive; current actual
-# is ~62%. Ratchet up as future PRs add tests.
+# 75% floor was set after the main+config_loader+API push; current actual
+# is ~76%. The remaining 4% to 80% lives mostly in lifespan startup hooks
+# and a few edge branches that aren't worth hand-rolling tests for.
 pytest-cov==6.0.0
 coverage==7.6.10

--- a/tests/integration/test_config_loader.py
+++ b/tests/integration/test_config_loader.py
@@ -1,0 +1,279 @@
+"""Tests for app/services/config_loader.py.
+
+`sync_sites_and_instances` is the lifespan-startup bootstrap that
+reconciles `pihole_instances.yml` with the DB on every container
+start. It was 12% covered before this file; the orphan-detection,
+main-reassignment, and rename paths run on every restart and have
+been the source of multiple production incidents.
+
+Tests monkeypatch `load_site_configs` to return SiteConfig lists
+directly so they don't depend on YAML file I/O.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+
+@pytest.fixture(autouse=True)
+def _ensure_fernet_key():
+    """sync_sites_and_instances writes the (encrypted) api_password,
+    which needs an active Fernet key."""
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+    yield
+
+
+def _site_cfg(name, slug, main=False, instances=()):
+    from app.config import SiteConfig
+    return SiteConfig(name=name, slug=slug, main=main, instances=list(instances))
+
+
+def _inst_cfg(name, url, master=False, vip_role=None, password=""):
+    from app.config import PiholeInstanceConfig
+    return PiholeInstanceConfig(
+        name=name, url=url, password=password, color="#3c8dbc",
+        master=master, vip_role=vip_role,
+    )
+
+
+# ── Initial run ──────────────────────────────────────────────────────────────
+
+
+async def test_initial_sync_creates_sites_and_instances(db_session, monkeypatch):
+    from app.services import config_loader
+    from app.models.pihole import PiholeInstance
+    from app.models.site import Site
+
+    site = _site_cfg("Main", "main", main=True, instances=[
+        _inst_cfg("p1", "http://10.0.0.1", master=True),
+        _inst_cfg("p2", "http://10.0.0.2"),
+    ])
+    monkeypatch.setattr(
+        config_loader, "load_site_configs", lambda: [site],
+    )
+
+    await config_loader.sync_sites_and_instances(db_session)
+
+    from app.database import AsyncSessionLocal
+    async with AsyncSessionLocal() as fresh:
+        sites = (await fresh.execute(select(Site))).scalars().all()
+        instances = (await fresh.execute(select(PiholeInstance))).scalars().all()
+
+    assert len(sites) == 1
+    assert sites[0].slug == "main"
+    assert sites[0].is_main is True
+    assert sites[0].is_active is True
+    assert len(instances) == 2
+    assert {i.name for i in instances} == {"p1", "p2"}
+    master = next(i for i in instances if i.name == "p1")
+    assert master.is_master is True
+
+
+async def test_sync_is_idempotent(db_session, monkeypatch):
+    """Re-running sync with the same YAML must not duplicate rows
+    or flip flags."""
+    from app.services import config_loader
+    from app.models.pihole import PiholeInstance
+    from app.models.site import Site
+
+    site = _site_cfg("Main", "main", main=True, instances=[
+        _inst_cfg("p1", "http://10.0.0.1", master=True),
+    ])
+    monkeypatch.setattr(
+        config_loader, "load_site_configs", lambda: [site],
+    )
+
+    await config_loader.sync_sites_and_instances(db_session)
+    await config_loader.sync_sites_and_instances(db_session)
+    await config_loader.sync_sites_and_instances(db_session)
+
+    from app.database import AsyncSessionLocal
+    async with AsyncSessionLocal() as fresh:
+        sites = (await fresh.execute(select(Site))).scalars().all()
+        instances = (await fresh.execute(select(PiholeInstance))).scalars().all()
+    assert len(sites) == 1
+    assert len(instances) == 1
+
+
+# ── Orphan detection ─────────────────────────────────────────────────────────
+
+
+async def test_removed_instance_marked_inactive(db_session, monkeypatch):
+    """An instance present in the previous YAML but absent in the
+    current one is marked is_active=False (not deleted)."""
+    from app.services import config_loader
+    from app.models.pihole import PiholeInstance
+
+    initial = _site_cfg("Main", "main", main=True, instances=[
+        _inst_cfg("p1", "http://10.0.0.1", master=True),
+        _inst_cfg("p2", "http://10.0.0.2"),
+    ])
+    monkeypatch.setattr(
+        config_loader, "load_site_configs", lambda: [initial],
+    )
+    await config_loader.sync_sites_and_instances(db_session)
+
+    # Now the YAML lost p2.
+    reduced = _site_cfg("Main", "main", main=True, instances=[
+        _inst_cfg("p1", "http://10.0.0.1", master=True),
+    ])
+    monkeypatch.setattr(
+        config_loader, "load_site_configs", lambda: [reduced],
+    )
+    await config_loader.sync_sites_and_instances(db_session)
+
+    from app.database import AsyncSessionLocal
+    async with AsyncSessionLocal() as fresh:
+        instances = (await fresh.execute(select(PiholeInstance))).scalars().all()
+    by_name = {i.name: i for i in instances}
+    assert by_name["p1"].is_active is True
+    assert by_name["p2"].is_active is False  # orphaned
+
+
+# ── Reactivation ─────────────────────────────────────────────────────────────
+
+
+async def test_returning_instance_is_reactivated(db_session, monkeypatch):
+    """An instance that was orphaned and is then re-added to the YAML
+    flips back to is_active=True without losing its stats history."""
+    from app.services import config_loader
+    from app.models.pihole import PiholeInstance
+
+    full = _site_cfg("Main", "main", main=True, instances=[
+        _inst_cfg("p1", "http://10.0.0.1", master=True),
+        _inst_cfg("p2", "http://10.0.0.2"),
+    ])
+    reduced = _site_cfg("Main", "main", main=True, instances=[
+        _inst_cfg("p1", "http://10.0.0.1", master=True),
+    ])
+    monkeypatch.setattr(config_loader, "load_site_configs", lambda: [full])
+    await config_loader.sync_sites_and_instances(db_session)
+    monkeypatch.setattr(config_loader, "load_site_configs", lambda: [reduced])
+    await config_loader.sync_sites_and_instances(db_session)
+    monkeypatch.setattr(config_loader, "load_site_configs", lambda: [full])
+    await config_loader.sync_sites_and_instances(db_session)
+
+    from app.database import AsyncSessionLocal
+    async with AsyncSessionLocal() as fresh:
+        instances = (await fresh.execute(select(PiholeInstance))).scalars().all()
+    p2 = next(i for i in instances if i.name == "p2")
+    assert p2.is_active is True
+
+
+# ── Main reassignment ────────────────────────────────────────────────────────
+
+
+async def test_main_reassignment_carries_settings_to_new_main(
+    db_session, monkeypatch,
+):
+    """When the YAML's Main flag moves to a different site, the old
+    Main's site_settings are materialised into the new Main where
+    that key is NULL/missing — so non-Main sites' inheritance still
+    resolves correctly."""
+    from app.services import config_loader
+    from app.models.site import Site, SiteSetting
+
+    # Start: site_a is Main, site_b is not.
+    monkeypatch.setattr(config_loader, "load_site_configs", lambda: [
+        _site_cfg("A", "site-a", main=True, instances=[]),
+        _site_cfg("B", "site-b", instances=[]),
+    ])
+    await config_loader.sync_sites_and_instances(db_session)
+
+    # Seed a setting on the old Main.
+    from app.database import AsyncSessionLocal
+    async with AsyncSessionLocal() as session:
+        a = (await session.execute(
+            select(Site).where(Site.slug == "site-a")
+        )).scalar_one()
+        session.add(SiteSetting(site_id=a.id, key="test_key", value="test_value"))
+        await session.commit()
+
+    # Flip Main flag in YAML.
+    monkeypatch.setattr(config_loader, "load_site_configs", lambda: [
+        _site_cfg("A", "site-a", instances=[]),
+        _site_cfg("B", "site-b", main=True, instances=[]),
+    ])
+    await config_loader.sync_sites_and_instances(db_session)
+
+    async with AsyncSessionLocal() as session:
+        sites = {s.slug: s for s in (
+            await session.execute(select(Site))
+        ).scalars().all()}
+        assert sites["site-a"].is_main is False
+        assert sites["site-b"].is_main is True
+
+        b_setting = (await session.execute(
+            select(SiteSetting).where(
+                SiteSetting.site_id == sites["site-b"].id,
+                SiteSetting.key == "test_key",
+            )
+        )).scalar_one_or_none()
+    assert b_setting is not None
+    assert b_setting.value == "test_value"
+
+
+# ── Main-rename in place ─────────────────────────────────────────────────────
+
+
+async def test_main_site_rename_preserves_data_via_slug_history(
+    db_session, monkeypatch,
+):
+    """When the YAML's only Main site has a different name+slug than
+    the DB's Main and no other site claims the new slug, treat as a
+    rename: stash the old slug in slug_history and update in place."""
+    from app.services import config_loader
+    from app.models.site import Site, SiteSlugHistory
+    from app.database import AsyncSessionLocal
+
+    monkeypatch.setattr(config_loader, "load_site_configs", lambda: [
+        _site_cfg("Default", "default", main=True, instances=[]),
+    ])
+    await config_loader.sync_sites_and_instances(db_session)
+
+    async with AsyncSessionLocal() as s:
+        original = (
+            await s.execute(select(Site).where(Site.slug == "default"))
+        ).scalar_one()
+    original_id = original.id
+
+    # Rename.
+    monkeypatch.setattr(config_loader, "load_site_configs", lambda: [
+        _site_cfg("WTR", "wtr", main=True, instances=[]),
+    ])
+    await config_loader.sync_sites_and_instances(db_session)
+
+    async with AsyncSessionLocal() as s:
+        sites = (await s.execute(select(Site))).scalars().all()
+        history = (await s.execute(select(SiteSlugHistory))).scalars().all()
+
+    # Same row, new slug + name.
+    assert len(sites) == 1
+    assert sites[0].id == original_id
+    assert sites[0].slug == "wtr"
+    assert sites[0].name == "WTR"
+    # Slug history captures the old slug.
+    assert any(h.old_slug == "default" for h in history)
+
+
+# ── Empty YAML ───────────────────────────────────────────────────────────────
+
+
+async def test_sync_with_no_sites_is_noop(db_session, monkeypatch):
+    """Empty / blank YAML returns early without touching the DB."""
+    from app.services import config_loader
+    from app.models.site import Site
+
+    monkeypatch.setattr(config_loader, "load_site_configs", lambda: [])
+    await config_loader.sync_sites_and_instances(db_session)
+
+    from app.database import AsyncSessionLocal
+    async with AsyncSessionLocal() as s:
+        sites = (await s.execute(select(Site))).scalars().all()
+    assert sites == []

--- a/tests/integration/test_domains_api.py
+++ b/tests/integration/test_domains_api.py
@@ -1,0 +1,165 @@
+"""Tests for /api/domains — block/unblock with master→replica fan-out
+mocked via respx."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ensure_fernet_key():
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+    yield
+
+
+@pytest.fixture(autouse=True)
+async def _clear_client_registry():
+    from app.services import client_manager
+    client_manager._clients.clear()
+    client_manager._last_persisted_sid.clear()
+    yield
+    for key in list(client_manager._clients):
+        try:
+            await client_manager._clients[key].close()
+        except Exception:
+            pass
+    client_manager._clients.clear()
+    client_manager._last_persisted_sid.clear()
+
+
+@pytest.fixture
+async def cluster(db_session):
+    from app.models.pihole import PiholeInstance
+    from app.models.site import Site
+
+    site = Site(
+        name="Main", slug="main", is_main=True, is_active=True, sort_order=0,
+    )
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    master = PiholeInstance(
+        site_id=site.id, name="master", url="http://master.test",
+        api_password="pw", is_active=True, is_master=True,
+    )
+    replica = PiholeInstance(
+        site_id=site.id, name="replica", url="http://replica.test",
+        api_password="pw", is_active=True, is_master=False,
+    )
+    db_session.add_all([master, replica])
+    await db_session.commit()
+    await db_session.refresh(master)
+    await db_session.refresh(replica)
+    return site, master, replica
+
+
+# ── Domain status ────────────────────────────────────────────────────────────
+
+
+async def test_get_domain_status_unauth_returns_401(client):
+    resp = await client.get("/api/domains/status/example.com")
+    assert resp.status_code == 401
+
+
+async def test_get_domain_status_returns_lookup_result(
+    authed_client, cluster, respx_mock,
+):
+    """GET /api/domains/status/{domain} hits the master's deny+allow
+    list lookups in parallel."""
+    _, master, _ = cluster
+    respx_mock.post(f"{master.url}/api/auth").respond(
+        200, json={"session": {"sid": "x"}}
+    )
+    respx_mock.get(f"{master.url}/api/domains/deny/exact").respond(
+        200, json={"domains": []}
+    )
+    respx_mock.get(f"{master.url}/api/domains/allow/exact").respond(
+        200, json={"domains": []}
+    )
+
+    resp = await authed_client.get("/api/domains/status/example.com")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "in_deny" in body
+    assert "in_allow" in body
+    assert body["in_deny"] is False
+    assert body["in_allow"] is False
+
+
+# ── Block + unblock ──────────────────────────────────────────────────────────
+
+
+async def test_add_to_deny_returns_per_instance_results(
+    authed_client, cluster, respx_mock,
+):
+    """POST /api/domains/deny first removes the domain from the allow
+    list (so it can't override) then adds it to deny — across master
+    + replica."""
+    _, master, replica = cluster
+
+    for url in (master.url, replica.url):
+        respx_mock.post(f"{url}/api/auth").respond(
+            200, json={"session": {"sid": "s"}}
+        )
+        # allow → deny means a DELETE on allow first, then POST on deny.
+        respx_mock.delete(f"{url}/api/domains/allow/exact/ads.example").respond(204)
+        respx_mock.post(f"{url}/api/domains/deny/exact").respond(200)
+
+    resp = await authed_client.post(
+        "/api/domains/deny", json={"domain": "ads.example"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "results" in body
+    assert len(body["results"]) == 2
+
+
+async def test_remove_from_deny_returns_per_instance_results(
+    authed_client, cluster, respx_mock,
+):
+    _, master, replica = cluster
+    for url in (master.url, replica.url):
+        respx_mock.post(f"{url}/api/auth").respond(
+            200, json={"session": {"sid": "s"}}
+        )
+        respx_mock.delete(f"{url}/api/domains/deny/exact/ads.example").respond(204)
+
+    resp = await authed_client.delete("/api/domains/deny/ads.example")
+    assert resp.status_code == 200
+    assert len(resp.json()["results"]) == 2
+
+
+async def test_add_to_allow_works_across_cluster(
+    authed_client, cluster, respx_mock,
+):
+    _, master, replica = cluster
+    for url in (master.url, replica.url):
+        respx_mock.post(f"{url}/api/auth").respond(
+            200, json={"session": {"sid": "s"}}
+        )
+        # add_to_allow does DELETE on deny first, then POST on allow.
+        respx_mock.delete(f"{url}/api/domains/deny/exact/needed.example").respond(204)
+        respx_mock.post(f"{url}/api/domains/allow/exact").respond(200)
+
+    resp = await authed_client.post(
+        "/api/domains/allow", json={"domain": "needed.example"},
+    )
+    assert resp.status_code == 200
+
+
+async def test_block_endpoint_blocked_for_readonly_key(
+    client, readonly_api_key, cluster,
+):
+    """Domain block is a mutation — read-only API keys must 403."""
+    resp = await client.post(
+        "/api/domains/deny",
+        headers={"X-API-Key": readonly_api_key},
+        json={"domain": "ads.example"},
+    )
+    assert resp.status_code == 403

--- a/tests/integration/test_more_apis.py
+++ b/tests/integration/test_more_apis.py
@@ -1,0 +1,288 @@
+"""More API + service coverage to push us above 80%.
+
+Hits the lower-coverage paths in api/instances, api/sites,
+api/stats history rollups, pushover load_settings + per-site sync
+notifications, and api/_site_dep slug-history-410 path."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ensure_fernet_key():
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+    yield
+
+
+# ── api/instances stale list + per-site variants ────────────────────────────
+
+
+@pytest.fixture
+async def site_with_stale(db_session):
+    from app.models.pihole import PiholeInstance
+    from app.models.site import Site
+
+    site = Site(name="Main", slug="main", is_main=True, is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    db_session.add_all([
+        PiholeInstance(
+            site_id=site.id, name="active1", url="http://a1",
+            api_password="p", is_active=True,
+        ),
+        PiholeInstance(
+            site_id=site.id, name="orphan1", url="http://o1",
+            api_password="p", is_active=False,
+        ),
+    ])
+    await db_session.commit()
+    return site
+
+
+async def test_list_stale_instances(authed_client, site_with_stale):
+    resp = await authed_client.get("/api/instances/stale")
+    assert resp.status_code == 200
+    body = resp.json()
+    names = {i["name"] for i in body}
+    assert "orphan1" in names
+    assert "active1" not in names
+
+
+async def test_list_instances_for_site(authed_client, site_with_stale):
+    site = site_with_stale
+    resp = await authed_client.get(f"/api/sites/{site.slug}/instances")
+    assert resp.status_code == 200
+    names = {i["name"] for i in resp.json()}
+    assert "active1" in names
+    assert "orphan1" not in names
+
+
+async def test_list_stale_instances_for_site(authed_client, site_with_stale):
+    site = site_with_stale
+    resp = await authed_client.get(f"/api/sites/{site.slug}/instances/stale")
+    assert resp.status_code == 200
+    names = {i["name"] for i in resp.json()}
+    assert "orphan1" in names
+
+
+# ── api/sites slug history 410 ──────────────────────────────────────────────
+
+
+async def test_delete_via_renamed_slug_returns_410(authed_client, db_session):
+    """Hitting DELETE /api/sites/{old_slug} after a rename returns 410
+    Gone with a hint that the slug was retired."""
+    from app.models.site import Site, SiteSlugHistory
+
+    site = Site(name="X", slug="new-x", is_active=False, sort_order=99)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    db_session.add(SiteSlugHistory(
+        old_slug="old-x", site_id=site.id,
+        retired_at=datetime.now(timezone.utc),
+    ))
+    await db_session.commit()
+
+    resp = await authed_client.delete("/api/sites/old-x")
+    assert resp.status_code == 410
+
+
+async def test_delete_unknown_site_returns_404(authed_client):
+    resp = await authed_client.delete("/api/sites/never-existed")
+    assert resp.status_code == 404
+
+
+# ── api/stats history with seeded data ──────────────────────────────────────
+
+
+@pytest.fixture
+async def site_with_history(db_session):
+    from app.models.pihole import PiholeInstance, QueryLog
+    from app.models.site import Site
+
+    site = Site(name="Main", slug="main-h", is_main=True, is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    inst = PiholeInstance(
+        site_id=site.id, name="p1", url="http://p1",
+        api_password="p", is_active=True,
+    )
+    db_session.add(inst)
+    await db_session.commit()
+    await db_session.refresh(inst)
+
+    now = datetime.now(timezone.utc)
+    rows = []
+    for i in range(60):
+        rows.append(QueryLog(
+            instance_id=inst.id,
+            timestamp=now - timedelta(minutes=i * 5),
+            domain=f"d{i % 5}.example",
+            client_ip=f"10.0.0.{(i % 4) + 1}",
+            client_name="host",
+            status="GRAVITY" if i % 3 == 0 else "OK",
+            query_type="A", reply_type="IP", reply_time_ms=1.0,
+        ))
+    db_session.add_all(rows)
+    await db_session.commit()
+    return site
+
+
+async def test_history_with_data_returns_buckets(authed_client, site_with_history):
+    """history reports rolling-stats from StatsSnapshot rows, so the
+    test fixture seeds QueryLog only — what matters is that the
+    endpoint returns a well-formed shape, not specific values."""
+    resp = await authed_client.get("/api/stats/history?hours=12")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "buckets" in body
+    assert isinstance(body["buckets"], list)
+
+
+async def test_history_per_site_filters_to_site(authed_client, site_with_history):
+    site = site_with_history
+    resp = await authed_client.get(f"/api/sites/{site.slug}/stats/history?hours=12")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["buckets"]) > 0
+
+
+async def test_top_per_site_with_data(authed_client, site_with_history):
+    site = site_with_history
+    resp = await authed_client.get(f"/api/sites/{site.slug}/stats/top?hours=12&limit=3")
+    body = resp.json()
+    assert len(body["top_blocked"]) >= 1
+
+
+# ── pushover load_settings ───────────────────────────────────────────────────
+
+
+async def test_pushover_load_settings_restores_module_state(db_session, monkeypatch):
+    """load_settings reads from site_settings under Main and copies
+    every field into module globals."""
+    from app.models.site import Site, SiteSetting
+    from app.services import pushover
+
+    monkeypatch.setattr(pushover, "_app_token", "")
+    monkeypatch.setattr(pushover, "_user_key", "")
+    monkeypatch.setattr(pushover, "_enabled", False)
+
+    site = Site(name="M", slug="m", is_main=True, is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    payload = {
+        "app_token": pushover._encrypt("loaded-tok"),
+        "user_key":  pushover._encrypt("loaded-key"),
+        "enabled": True,
+        "alert_sync_failure": True,
+        "alert_instance_offline": True,
+        "alert_high_block_rate": False,
+        "alert_on_vip_transfer": True,
+        "block_rate_threshold_pct": 60.0,
+        "offline_alert_max_count": 3,
+        "offline_alert_retries": 2,
+    }
+    db_session.add(SiteSetting(
+        site_id=site.id, key="pushover_settings", value=json.dumps(payload),
+    ))
+    await db_session.commit()
+
+    await pushover.load_settings()
+
+    assert pushover._app_token == "loaded-tok"
+    assert pushover._user_key == "loaded-key"
+    assert pushover._enabled is True
+    assert pushover._offline_alert_retries == 2
+    assert pushover._block_rate_threshold_pct == 60.0
+
+
+# ── pushover notify_sync_failure with site_id ────────────────────────────────
+
+
+async def test_notify_sync_failure_with_site_id_honours_per_site_toggle(
+    db_session, respx_mock,
+):
+    """alert_sync_failure=False per-site → no Pushover call."""
+    from app.models.site import Site, SiteSetting
+    from app.services import pushover
+
+    site = Site(name="X", slug="xx", is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    payload = {
+        "app_token": pushover._encrypt("t"),
+        "user_key":  pushover._encrypt("k"),
+        "enabled": True,
+        "alert_sync_failure": False,  # ← gate
+        "alert_instance_offline": True,
+        "alert_high_block_rate": False,
+        "alert_on_vip_transfer": False,
+        "block_rate_threshold_pct": 50.0,
+        "offline_alert_max_count": 1,
+        "offline_alert_retries": 1,
+    }
+    db_session.add(SiteSetting(
+        site_id=site.id, key="pushover_settings", value=json.dumps(payload),
+    ))
+    await db_session.commit()
+
+    route = respx_mock.post(
+        "https://api.pushover.net/1/messages.json"
+    ).respond(200, json={"status": 1})
+
+    await pushover.notify_sync_failure("error", site_name="X", site_id=site.id)
+    assert route.call_count == 0
+
+
+async def test_notify_instance_back_online_with_site_id(
+    db_session, respx_mock,
+):
+    from app.models.site import Site, SiteSetting
+    from app.services import pushover
+
+    site = Site(name="Y", slug="yy", is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    payload = {
+        "app_token": pushover._encrypt("t"),
+        "user_key":  pushover._encrypt("k"),
+        "enabled": True,
+        "alert_sync_failure": True,
+        "alert_instance_offline": True,
+        "alert_high_block_rate": False,
+        "alert_on_vip_transfer": False,
+        "block_rate_threshold_pct": 50.0,
+        "offline_alert_max_count": 1,
+        "offline_alert_retries": 1,
+    }
+    db_session.add(SiteSetting(
+        site_id=site.id, key="pushover_settings", value=json.dumps(payload),
+    ))
+    await db_session.commit()
+
+    route = respx_mock.post(
+        "https://api.pushover.net/1/messages.json"
+    ).respond(200, json={"status": 1})
+
+    await pushover.notify_instance_back_online("p1", site_id=site.id)
+    assert route.call_count == 1

--- a/tests/integration/test_pihole_version_check.py
+++ b/tests/integration/test_pihole_version_check.py
@@ -1,0 +1,102 @@
+"""Tests for app/services/pihole_version_check.py — the hourly poll
+that fetches Pi-hole core/FTL/web release versions from GitHub and
+flags `update_available_*` on each instance row."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_module(monkeypatch):
+    from app.services import pihole_version_check
+    monkeypatch.setattr(pihole_version_check, "_enabled", True)
+    monkeypatch.setattr(pihole_version_check, "_latest", {})
+    monkeypatch.setattr(pihole_version_check, "_checked_at", None)
+    monkeypatch.setattr(pihole_version_check, "_check_in_progress", False)
+    yield
+
+
+def test_compute_update_available_with_no_installed_returns_none():
+    from app.services import pihole_version_check
+    assert pihole_version_check.compute_update_available(None, "core") is None
+    assert pihole_version_check.compute_update_available("", "core") is None
+
+
+def test_compute_update_available_with_no_cached_returns_none():
+    """`_latest` empty → can't compute, returns None so callers can
+    distinguish 'not yet checked' from 'up to date'."""
+    from app.services import pihole_version_check
+    assert pihole_version_check.compute_update_available("6.4.2", "core") is None
+
+
+def test_compute_update_available_compares_strings(monkeypatch):
+    from app.services import pihole_version_check
+    monkeypatch.setattr(pihole_version_check, "_latest", {
+        "core": "6.4.2", "ftl": "6.6.1", "web": "6.5",
+    })
+    assert pihole_version_check.compute_update_available("6.4.2", "core") is False
+    assert pihole_version_check.compute_update_available("6.4.1", "core") is True
+
+
+async def test_check_now_fetches_three_repos_and_strips_v(respx_mock):
+    """Iterates _REPOS and stores tags with leading 'v' stripped."""
+    from app.services import pihole_version_check
+
+    respx_mock.get(
+        "https://api.github.com/repos/pi-hole/pi-hole/releases/latest"
+    ).respond(200, json={"tag_name": "v6.4.2"})
+    respx_mock.get(
+        "https://api.github.com/repos/pi-hole/FTL/releases/latest"
+    ).respond(200, json={"tag_name": "v6.6.1"})
+    respx_mock.get(
+        "https://api.github.com/repos/pi-hole/web/releases/latest"
+    ).respond(200, json={"tag_name": "v6.5"})
+
+    await pihole_version_check.check_now()
+
+    status = pihole_version_check.get_status()
+    assert status["latest_core"] == "6.4.2"
+    assert status["latest_ftl"] == "6.6.1"
+    assert status["latest_web"] == "6.5"
+    assert status["checked_at"] is not None
+
+
+async def test_check_now_disabled_skips_http(respx_mock):
+    from app.services import pihole_version_check
+
+    route = respx_mock.get(
+        "https://api.github.com/repos/pi-hole/pi-hole/releases/latest"
+    ).respond(200, json={"tag_name": "v6.4.2"})
+
+    pihole_version_check._enabled = False
+    await pihole_version_check.check_now()
+    assert route.call_count == 0
+
+
+async def test_check_now_preserves_last_known_on_transient_failure(respx_mock, monkeypatch):
+    """A 500 on a single repo doesn't blank that component's cached
+    value — operators don't lose 'update available' indicators when
+    GitHub momentarily errors."""
+    from app.services import pihole_version_check
+
+    monkeypatch.setattr(pihole_version_check, "_latest", {
+        "core": "6.4.2", "ftl": "6.6.1", "web": "6.5",
+    })
+
+    respx_mock.get(
+        "https://api.github.com/repos/pi-hole/pi-hole/releases/latest"
+    ).respond(500)
+    respx_mock.get(
+        "https://api.github.com/repos/pi-hole/FTL/releases/latest"
+    ).respond(200, json={"tag_name": "v6.6.2"})
+    respx_mock.get(
+        "https://api.github.com/repos/pi-hole/web/releases/latest"
+    ).respond(200, json={"tag_name": "v6.5"})
+
+    await pihole_version_check.check_now()
+    status = pihole_version_check.get_status()
+    # core preserved
+    assert status["latest_core"] == "6.4.2"
+    # ftl + web updated
+    assert status["latest_ftl"] == "6.6.2"
+    assert status["latest_web"] == "6.5"

--- a/tests/integration/test_pushover_advanced.py
+++ b/tests/integration/test_pushover_advanced.py
@@ -1,0 +1,276 @@
+"""Advanced Pushover tests — exercises the _post HTTP path with respx
+and the per-site config resolution that the basic test_pushover_service
+file from PR 5 doesn't reach."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ensure_fernet_key():
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_pushover_module(monkeypatch):
+    from app.services import pushover
+    monkeypatch.setattr(pushover, "_app_token", "")
+    monkeypatch.setattr(pushover, "_user_key", "")
+    monkeypatch.setattr(pushover, "_enabled", False)
+    yield
+
+
+# ── _post (the actual HTTP path) ─────────────────────────────────────────────
+
+
+async def test_send_makes_http_call_when_enabled(respx_mock):
+    """With creds + enabled, send() POSTs to api.pushover.net."""
+    from app.services import pushover
+
+    pushover._enabled = True
+    pushover._app_token = "tok"
+    pushover._user_key = "key"
+
+    route = respx_mock.post(
+        "https://api.pushover.net/1/messages.json"
+    ).respond(200, json={"status": 1})
+
+    ok = await pushover.send("hello", title="MyPi")
+    assert ok is True
+    assert route.call_count == 1
+
+
+async def test_send_returns_false_on_pushover_error_response(respx_mock):
+    """status != 1 in the response body means Pushover rejected the
+    payload. send() returns False without raising."""
+    from app.services import pushover
+
+    pushover._enabled = True
+    pushover._app_token = "tok"
+    pushover._user_key = "key"
+
+    respx_mock.post(
+        "https://api.pushover.net/1/messages.json"
+    ).respond(200, json={"status": 0, "errors": ["app token bad"]})
+
+    ok = await pushover.send("hello")
+    assert ok is False
+
+
+async def test_send_returns_false_on_transport_error(respx_mock):
+    """A network error during _post is logged and swallowed — the
+    scheduler tick mustn't crash because Pushover is unreachable."""
+    import httpx
+    from app.services import pushover
+
+    pushover._enabled = True
+    pushover._app_token = "tok"
+    pushover._user_key = "key"
+
+    respx_mock.post(
+        "https://api.pushover.net/1/messages.json"
+    ).mock(side_effect=httpx.ConnectError("no route to host"))
+
+    ok = await pushover.send("hello")
+    assert ok is False
+
+
+async def test_send_test_uses_credentials_regardless_of_enabled(respx_mock):
+    """send_test ignores the `enabled` flag — used from the Settings
+    page to verify creds before turning notifications on."""
+    from app.services import pushover
+
+    pushover._enabled = False  # disabled
+    pushover._app_token = "tok"
+    pushover._user_key = "key"
+
+    route = respx_mock.post(
+        "https://api.pushover.net/1/messages.json"
+    ).respond(200, json={"status": 1})
+
+    ok = await pushover.send_test()
+    assert ok is True
+    assert route.call_count == 1
+
+
+# ── validate ────────────────────────────────────────────────────────────────
+
+
+async def test_validate_calls_pushover_validate_endpoint(respx_mock):
+    from app.services import pushover
+
+    respx_mock.post(
+        "https://api.pushover.net/1/users/validate.json"
+    ).respond(200, json={"status": 1})
+
+    ok, err = await pushover.validate("tok", "key")
+    assert ok is True
+    assert err == ""
+
+
+async def test_validate_surfaces_pushover_error_strings(respx_mock):
+    from app.services import pushover
+
+    respx_mock.post(
+        "https://api.pushover.net/1/users/validate.json"
+    ).respond(200, json={"status": 0, "errors": ["application token is invalid"]})
+
+    ok, err = await pushover.validate("tok", "key")
+    assert ok is False
+    assert "invalid" in err.lower()
+
+
+async def test_validate_handles_transport_error():
+    """No respx route configured → httpx fails → validate returns
+    (False, error_string) instead of raising."""
+    from app.services import pushover
+
+    ok, err = await pushover.validate("tok", "key")
+    assert ok is False
+    assert err  # some error string
+
+
+# ── Per-site send + config resolution ────────────────────────────────────────
+
+
+async def test_send_with_site_id_resolves_per_site_config(
+    db_session, respx_mock,
+):
+    """When site_id is passed, send() loads the site_settings row,
+    decrypts the credentials, and uses them. The Main-only in-memory
+    config is bypassed."""
+    from app.models.site import Site, SiteSetting
+    from app.services import pushover
+
+    site = Site(name="X", slug="x", is_main=True, is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    payload = {
+        "app_token": pushover._encrypt("site-tok"),
+        "user_key":  pushover._encrypt("site-key"),
+        "enabled": True,
+        "alert_sync_failure": True,
+        "alert_instance_offline": True,
+        "alert_high_block_rate": False,
+        "alert_on_vip_transfer": False,
+        "block_rate_threshold_pct": 50.0,
+        "offline_alert_max_count": 1,
+        "offline_alert_retries": 1,
+    }
+    db_session.add(SiteSetting(
+        site_id=site.id, key="pushover_settings", value=json.dumps(payload),
+    ))
+    await db_session.commit()
+
+    route = respx_mock.post(
+        "https://api.pushover.net/1/messages.json"
+    ).respond(200, json={"status": 1})
+
+    ok = await pushover.send("hello", site_id=site.id)
+    assert ok is True
+    assert route.call_count == 1
+
+
+async def test_send_with_site_id_no_config_returns_false(db_session):
+    """A site without persisted Pushover config can't send — return
+    False rather than falling back to the (potentially unrelated)
+    Main config."""
+    from app.models.site import Site
+    from app.services import pushover
+
+    site = Site(name="No config", slug="nopush", is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    ok = await pushover.send("body", site_id=site.id)
+    assert ok is False
+
+
+# ── Per-site notification helpers ────────────────────────────────────────────
+
+
+async def test_notify_instance_offline_with_site_id_honours_per_site_toggle(
+    db_session, respx_mock,
+):
+    """When site_id is passed and the site's alert_instance_offline
+    is False, the helper short-circuits and never POSTs."""
+    from app.models.site import Site, SiteSetting
+    from app.services import pushover
+
+    site = Site(name="Z", slug="z", is_main=True, is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    payload = {
+        "app_token": pushover._encrypt("t"),
+        "user_key":  pushover._encrypt("k"),
+        "enabled": True,
+        "alert_sync_failure": False,
+        "alert_instance_offline": False,  # ← gate
+        "alert_high_block_rate": False,
+        "alert_on_vip_transfer": False,
+        "block_rate_threshold_pct": 50.0,
+        "offline_alert_max_count": 1,
+        "offline_alert_retries": 1,
+    }
+    db_session.add(SiteSetting(
+        site_id=site.id, key="pushover_settings", value=json.dumps(payload),
+    ))
+    await db_session.commit()
+
+    route = respx_mock.post(
+        "https://api.pushover.net/1/messages.json"
+    ).respond(200, json={"status": 1})
+
+    await pushover.notify_instance_offline("p1", site_id=site.id)
+    assert route.call_count == 0  # gated off
+
+
+async def test_notify_vip_transfer_with_site_id_honours_per_site_toggle(
+    db_session, respx_mock,
+):
+    from app.models.site import Site, SiteSetting
+    from app.services import pushover
+
+    site = Site(name="V", slug="v", is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    # Site config has alert_on_vip_transfer=False — must not fire.
+    payload = {
+        "app_token": pushover._encrypt("t"),
+        "user_key":  pushover._encrypt("k"),
+        "enabled": True,
+        "alert_sync_failure": True,
+        "alert_instance_offline": True,
+        "alert_high_block_rate": False,
+        "alert_on_vip_transfer": False,
+        "block_rate_threshold_pct": 50.0,
+        "offline_alert_max_count": 1,
+        "offline_alert_retries": 1,
+    }
+    db_session.add(SiteSetting(
+        site_id=site.id, key="pushover_settings", value=json.dumps(payload),
+    ))
+    await db_session.commit()
+
+    route = respx_mock.post(
+        "https://api.pushover.net/1/messages.json"
+    ).respond(200, json={"status": 1})
+
+    await pushover.notify_vip_transfer("master", "replica", site_id=site.id)
+    assert route.call_count == 0

--- a/tests/integration/test_queries_api_filters.py
+++ b/tests/integration/test_queries_api_filters.py
@@ -1,0 +1,152 @@
+"""Tests for /api/queries filtering, pagination, sorting, and the
+client-summary endpoint. Complements test_queries.py (SSE) from PR 5."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ensure_fernet_key():
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+    yield
+
+
+@pytest.fixture
+async def site_with_queries(db_session):
+    from app.models.pihole import PiholeInstance, QueryLog
+    from app.models.site import Site
+
+    site = Site(
+        name="Main", slug="main", is_main=True, is_active=True, sort_order=0,
+    )
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    inst = PiholeInstance(
+        site_id=site.id, name="p1", url="http://p1",
+        api_password="pw", is_active=True,
+    )
+    db_session.add(inst)
+    await db_session.commit()
+    await db_session.refresh(inst)
+
+    now = datetime.now(timezone.utc)
+    rows = [
+        QueryLog(
+            instance_id=inst.id,
+            timestamp=now - timedelta(minutes=i),
+            domain=f"site{i % 4}.example",
+            client_ip=f"10.0.0.{i % 3 + 1}",
+            client_name=f"host{i % 3 + 1}",
+            status="GRAVITY" if i % 3 == 0 else "OK",
+            query_type="A", reply_type="IP", reply_time_ms=1.5 * i,
+        )
+        for i in range(50)
+    ]
+    db_session.add_all(rows)
+    await db_session.commit()
+    return site, inst
+
+
+# ── Basic GET /api/queries ───────────────────────────────────────────────────
+
+
+async def test_queries_default_returns_paginated(authed_client, site_with_queries):
+    resp = await authed_client.get("/api/queries")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "total" in body
+    assert "items" in body
+    assert body["total"] >= 1
+    assert body["page"] == 1
+
+
+async def test_queries_pagination_respects_page_size(authed_client, site_with_queries):
+    resp = await authed_client.get("/api/queries?page_size=5&page=1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["items"]) <= 5
+    assert body["page_size"] == 5
+
+
+async def test_queries_filter_by_domain(authed_client, site_with_queries):
+    resp = await authed_client.get("/api/queries?domain=site0")
+    assert resp.status_code == 200
+    body = resp.json()
+    for item in body["items"]:
+        assert "site0" in item["domain"]
+
+
+async def test_queries_filter_by_client(authed_client, site_with_queries):
+    resp = await authed_client.get("/api/queries?client=10.0.0.1")
+    assert resp.status_code == 200
+    body = resp.json()
+    for item in body["items"]:
+        assert "10.0.0.1" in item["client_ip"]
+
+
+async def test_queries_filter_blocked_only(authed_client, site_with_queries):
+    resp = await authed_client.get("/api/queries?blocked=true")
+    assert resp.status_code == 200
+    body = resp.json()
+    for item in body["items"]:
+        # GRAVITY is one of the BLOCKED_STATUSES — every item must be in the set.
+        assert item["status"] in {
+            "GRAVITY", "REGEX", "BLACKLIST",
+            "EXTERNAL_BLOCKED_IP", "EXTERNAL_BLOCKED_NULL",
+            "EXTERNAL_BLOCKED_NXDOMAIN",
+            "GRAVITY_CNAME", "REGEX_CNAME", "BLACKLIST_CNAME",
+        }
+
+
+async def test_queries_sort_by_domain_asc(authed_client, site_with_queries):
+    resp = await authed_client.get("/api/queries?sort_by=domain&sort_dir=asc")
+    body = resp.json()
+    domains = [item["domain"] for item in body["items"]]
+    assert domains == sorted(domains)
+
+
+async def test_queries_unauth_returns_401(client):
+    resp = await client.get("/api/queries")
+    assert resp.status_code == 401
+
+
+# ── /api/queries/clients ─────────────────────────────────────────────────────
+
+
+async def test_client_summary_aggregates_by_client(authed_client, site_with_queries):
+    resp = await authed_client.get("/api/queries/clients")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) >= 1
+    assert "total_queries" in body[0]
+    assert "blocked_queries" in body[0]
+
+
+# ── Per-site variants ────────────────────────────────────────────────────────
+
+
+async def test_queries_per_site_returns_only_site_data(
+    authed_client, site_with_queries,
+):
+    site, _ = site_with_queries
+    resp = await authed_client.get(f"/api/sites/{site.slug}/queries")
+    assert resp.status_code == 200
+    assert resp.json()["total"] >= 1
+
+
+async def test_queries_per_site_clients_aggregate(authed_client, site_with_queries):
+    site, _ = site_with_queries
+    resp = await authed_client.get(f"/api/sites/{site.slug}/queries/clients")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)

--- a/tests/integration/test_remaining_apis.py
+++ b/tests/integration/test_remaining_apis.py
@@ -1,0 +1,314 @@
+"""Tests for the smaller API surface — sites PATCH (rename + slug
+history), api/_site_dep slug-history redirect, /api/auth session-
+timeout + list-keys, /api/version + /api/display + /api/poll-settings."""
+from __future__ import annotations
+
+import pytest
+
+
+# ── /api/sites PATCH ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def two_sites(db_session):
+    from app.models.site import Site
+    a = Site(name="A", slug="a", is_main=True, is_active=True, sort_order=0)
+    b = Site(name="B", slug="b", is_main=False, is_active=True, sort_order=1)
+    db_session.add_all([a, b])
+    await db_session.commit()
+    await db_session.refresh(a)
+    await db_session.refresh(b)
+    return a, b
+
+
+async def test_patch_site_renames_in_place(authed_client, two_sites):
+    a, _ = two_sites
+    resp = await authed_client.patch(
+        f"/api/sites/{a.slug}", json={"name": "A-Renamed"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "A-Renamed"
+
+
+async def test_patch_site_changes_slug_and_writes_history(
+    authed_client, two_sites, db_session,
+):
+    """Slug change writes the old slug into site_slug_history so
+    bookmarks keep working via 301."""
+    from app.models.site import SiteSlugHistory
+    from sqlalchemy import select
+
+    a, _ = two_sites
+    old_slug = a.slug
+    resp = await authed_client.patch(
+        f"/api/sites/{old_slug}", json={"slug": "a-renamed"},
+    )
+    assert resp.status_code == 200
+
+    from app.database import AsyncSessionLocal
+    async with AsyncSessionLocal() as fresh:
+        history = (
+            await fresh.execute(
+                select(SiteSlugHistory).where(SiteSlugHistory.old_slug == old_slug)
+            )
+        ).scalars().all()
+    assert len(history) == 1
+
+
+async def test_patch_site_rejects_conflicting_slug(authed_client, two_sites):
+    """If another active site already owns the requested slug,
+    PATCH returns 409."""
+    a, b = two_sites
+    resp = await authed_client.patch(
+        f"/api/sites/{a.slug}", json={"slug": b.slug},
+    )
+    assert resp.status_code == 409
+
+
+async def test_patch_site_uppercase_slug_is_normalised(
+    authed_client, two_sites,
+):
+    """An operator who types a display name (uppercase / spaces) gets
+    it slugified rather than rejected — by design."""
+    a, _ = two_sites
+    resp = await authed_client.patch(
+        f"/api/sites/{a.slug}", json={"slug": "New Name"},
+    )
+    # slugify("New Name") = "new-name" → valid → 200
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "new-name"
+
+
+# ── api/_site_dep slug-history redirect ──────────────────────────────────────
+
+
+async def test_old_slug_resolves_via_history_redirect(
+    authed_client, two_sites, db_session,
+):
+    """Hitting /api/sites/{old_slug}/something after a rename returns
+    a 301 redirect to the new slug — bookmarks survive renames."""
+    from app.models.site import SiteSlugHistory
+    from datetime import datetime, timezone
+
+    a, _ = two_sites
+    db_session.add(SiteSlugHistory(
+        old_slug="legacy-a", site_id=a.id,
+        retired_at=datetime.now(timezone.utc),
+    ))
+    await db_session.commit()
+
+    resp = await authed_client.get("/api/sites/legacy-a", follow_redirects=False)
+    # resolve_site issues a 301 to the canonical slug.
+    assert resp.status_code in (301, 308)
+
+
+# ── /api/auth — session-timeout + list-keys ─────────────────────────────────
+
+
+async def test_session_timeout_get_returns_value(authed_client):
+    resp = await authed_client.get("/api/auth/session-timeout")
+    assert resp.status_code == 200
+    assert "timeout_minutes" in resp.json()
+
+
+async def test_session_timeout_set_round_trip(authed_client):
+    set_resp = await authed_client.put(
+        "/api/auth/session-timeout", json={"timeout_minutes": 30},
+    )
+    assert set_resp.status_code == 200
+
+    get_resp = await authed_client.get("/api/auth/session-timeout")
+    assert get_resp.json()["timeout_minutes"] == 30
+
+
+async def test_session_timeout_negative_rejected(authed_client):
+    resp = await authed_client.put(
+        "/api/auth/session-timeout", json={"timeout_minutes": -1},
+    )
+    assert resp.status_code == 422
+
+
+async def test_list_api_keys_excludes_other_users_keys(
+    authed_client, db_session, test_user,
+):
+    """User can only see their own keys, not other users'."""
+    from app.auth import generate_api_key
+    from app.models.user import ApiKey, User
+    from app.auth import hash_password
+
+    other = User(
+        username="bob", hashed_password=hash_password("p"),
+        is_active=True, password_change_required=False,
+    )
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(other)
+
+    _, h = generate_api_key()
+    db_session.add(ApiKey(
+        user_id=other.id, name="bob-key", key_hash=h,
+        key_hash_algo="hmac-sha256", is_active=True, is_read_only=False,
+    ))
+    await db_session.commit()
+
+    resp = await authed_client.get("/api/auth/api-keys")
+    body = resp.json()
+    # The fixture user is "alice" — bob's key must NOT be in the list.
+    assert all(k["name"] != "bob-key" for k in body)
+
+
+# ── /api/version ─────────────────────────────────────────────────────────────
+
+
+async def test_version_status_endpoint(authed_client):
+    resp = await authed_client.get("/api/version/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "current_version" in body
+    assert "enabled" in body
+
+
+async def test_version_settings_save(authed_client):
+    resp = await authed_client.put(
+        "/api/version/settings", json={"enabled": False},
+    )
+    assert resp.status_code == 200
+
+
+async def test_version_check_endpoint_triggers_check(authed_client, respx_mock):
+    """POST /api/version/check forces an immediate version_check.check_now."""
+    respx_mock.get(
+        "https://raw.githubusercontent.com/theojamesvibes/mypi/main/VERSION"
+    ).respond(200, text="2.0.5\n")
+
+    resp = await authed_client.post("/api/version/check")
+    assert resp.status_code == 200
+
+
+# ── /api/display-settings ────────────────────────────────────────────────────
+
+
+async def test_display_settings_get_returns_current(authed_client, db_session):
+    """Display settings live under Main — need a Main site."""
+    from app.models.site import Site
+    db_session.add(Site(
+        name="M", slug="m", is_main=True, is_active=True, sort_order=0,
+    ))
+    await db_session.commit()
+
+    resp = await authed_client.get("/api/display-settings")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), dict)
+
+
+async def test_display_settings_round_trip(authed_client, db_session):
+    from app.models.site import Site
+    db_session.add(Site(
+        name="M", slug="m", is_main=True, is_active=True, sort_order=0,
+    ))
+    await db_session.commit()
+
+    resp = await authed_client.put(
+        "/api/display-settings",
+        json={"hide_pihole_self_in_top_clients": False},
+    )
+    assert resp.status_code == 200
+
+
+# ── /api/poll-settings ───────────────────────────────────────────────────────
+
+
+async def test_poll_settings_get(authed_client):
+    # The router has a trailing-slash route — let httpx follow the
+    # 307 if FastAPI issues one.
+    resp = await authed_client.get("/api/poll-settings/", follow_redirects=True)
+    assert resp.status_code == 200
+    assert "interval_seconds" in resp.json()
+
+
+async def test_poll_settings_put_round_trip(authed_client, db_session):
+    from app.models.site import Site
+    db_session.add(Site(
+        name="M", slug="m", is_main=True, is_active=True, sort_order=0,
+    ))
+    await db_session.commit()
+
+    resp = await authed_client.put(
+        "/api/poll-settings/", json={"interval_seconds": 30},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+
+
+async def test_poll_settings_put_blocked_for_readonly_key(
+    client, readonly_api_key,
+):
+    resp = await client.put(
+        "/api/poll-settings/",
+        headers={"X-API-Key": readonly_api_key},
+        json={"interval_seconds": 30},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 403
+
+
+# ── /api/instances DELETE for orphan ─────────────────────────────────────────
+
+
+async def test_delete_inactive_instance_succeeds(authed_client, db_session):
+    """An is_active=False instance can be permanently deleted via DELETE
+    /api/instances/{id}."""
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    from app.models.pihole import PiholeInstance
+    from app.models.site import Site
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+
+    site = Site(name="Main", slug="main", is_main=True, is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    inst = PiholeInstance(
+        site_id=site.id, name="zombie", url="http://z",
+        api_password="pw", is_active=False,
+    )
+    db_session.add(inst)
+    await db_session.commit()
+    await db_session.refresh(inst)
+
+    resp = await authed_client.delete(f"/api/instances/{inst.id}")
+    assert resp.status_code == 204
+
+
+async def test_delete_active_instance_returns_409(authed_client, db_session):
+    """Active instances must be removed from YAML first."""
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    from app.models.pihole import PiholeInstance
+    from app.models.site import Site
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+
+    site = Site(name="Main", slug="main", is_main=True, is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    inst = PiholeInstance(
+        site_id=site.id, name="active", url="http://a",
+        api_password="pw", is_active=True,
+    )
+    db_session.add(inst)
+    await db_session.commit()
+    await db_session.refresh(inst)
+
+    resp = await authed_client.delete(f"/api/instances/{inst.id}")
+    assert resp.status_code == 409

--- a/tests/integration/test_settings_services.py
+++ b/tests/integration/test_settings_services.py
@@ -1,0 +1,114 @@
+"""Tests for the small persistence-helper services that the
+notifications/sync/poll/session settings pages all rely on:
+session_settings, poll_settings, site_settings."""
+from __future__ import annotations
+
+import pytest
+
+
+# ── session_settings (timeout) ───────────────────────────────────────────────
+
+
+async def test_session_timeout_round_trip(db_session):
+    from app.services import session_settings
+
+    # Default is no-timeout (0). Save a non-zero value.
+    await session_settings.save_settings(60)
+    assert session_settings.get_timeout_minutes() == 60
+
+    # Reload from DB simulates a fresh container.
+    await session_settings.load_settings()
+    assert session_settings.get_timeout_minutes() == 60
+
+
+async def test_session_timeout_effective_minutes_clamps_zero():
+    """0 means 'no timeout' in the API but the JWT still needs an
+    expiry — `effective_minutes` clamps 0 to a long horizon."""
+    from app.services import session_settings
+
+    # 0 → some sensible long value (not literal 0).
+    eff = session_settings.effective_minutes(0)
+    assert eff > 0
+
+
+# ── poll_settings ────────────────────────────────────────────────────────────
+
+
+async def test_poll_settings_get_default_interval():
+    from app.services import poll_settings as ps_service
+    interval = ps_service.get_interval_seconds()
+    assert isinstance(interval, int)
+    assert interval > 0
+
+
+async def test_poll_settings_save_persists_and_reloads(db_session, monkeypatch):
+    from app.models.site import Site
+    from app.services import poll_settings as ps_service
+
+    # save_settings requires a Main site (intervals are stored under it).
+    db_session.add(Site(
+        name="Main", slug="main", is_main=True, is_active=True, sort_order=0,
+    ))
+    await db_session.commit()
+
+    captured = []
+    ps_service.set_reschedule_callback(lambda new_seconds: captured.append(new_seconds))
+
+    await ps_service.save_settings(45)
+    assert ps_service.get_interval_seconds() == 45
+    assert captured == [45]
+
+    # Reload simulates a fresh container.
+    await ps_service.load_settings()
+    assert ps_service.get_interval_seconds() == 45
+
+
+# ── site_settings (per-site key/value with Main inheritance) ─────────────────
+
+
+async def test_site_settings_set_and_get_round_trip(db_session):
+    from app.models.site import Site
+    from app.services import site_settings
+
+    site = Site(name="A", slug="a", is_main=True, is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    await site_settings.set_setting(db_session, site.id, "test_key", "test_value")
+
+    val = await site_settings.get_setting(db_session, site.id, "test_key")
+    assert val == "test_value"
+
+
+async def test_site_settings_get_returns_none_for_missing_key(db_session):
+    from app.models.site import Site
+    from app.services import site_settings
+
+    site = Site(name="A", slug="a", is_main=True, is_active=True, sort_order=0)
+    db_session.add(site)
+    await db_session.commit()
+    await db_session.refresh(site)
+
+    val = await site_settings.get_setting(db_session, site.id, "nope")
+    assert val is None
+
+
+async def test_get_main_site_id_returns_active_main(db_session):
+    from app.models.site import Site
+    from app.services import site_settings
+
+    main = Site(name="M", slug="m", is_main=True, is_active=True, sort_order=0)
+    other = Site(name="O", slug="o", is_main=False, is_active=True, sort_order=1)
+    db_session.add_all([main, other])
+    await db_session.commit()
+    await db_session.refresh(main)
+
+    main_id = await site_settings.get_main_site_id(db_session)
+    assert main_id == main.id
+
+
+async def test_get_main_site_id_returns_none_when_no_main(db_session):
+    from app.services import site_settings
+    main_id = await site_settings.get_main_site_id(db_session)
+    assert main_id is None

--- a/tests/integration/test_stats_api.py
+++ b/tests/integration/test_stats_api.py
@@ -1,0 +1,140 @@
+"""Tests for /api/stats — summary, history, top."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+
+@pytest.fixture(autouse=True)
+def _ensure_fernet_key():
+    from cryptography.fernet import Fernet
+    from app.config import settings
+    import app.models.pihole as pihole_models
+
+    if not settings.encryption_key:
+        settings.encryption_key = Fernet.generate_key().decode()
+        pihole_models._fernet = None
+    yield
+
+
+@pytest.fixture
+async def site(db_session):
+    from app.models.site import Site
+    s = Site(name="Main", slug="main", is_main=True, is_active=True, sort_order=0)
+    db_session.add(s)
+    await db_session.commit()
+    await db_session.refresh(s)
+    return s
+
+
+@pytest.fixture
+async def instance(db_session, site):
+    from app.models.pihole import PiholeInstance
+    i = PiholeInstance(
+        site_id=site.id, name="p1", url="http://p1",
+        api_password="pw", is_active=True, is_master=True,
+    )
+    db_session.add(i)
+    await db_session.commit()
+    await db_session.refresh(i)
+    return i
+
+
+@pytest.fixture
+async def seed_data(db_session, instance):
+    """Some StatsSnapshot rows + QueryLog rows so the aggregate
+    endpoints have something to chew on."""
+    from app.models.pihole import QueryLog, StatsSnapshot
+
+    now = datetime.now(timezone.utc)
+    db_session.add_all([
+        StatsSnapshot(
+            instance_id=instance.id,
+            collected_at=now - timedelta(minutes=1),
+            status="online",
+            dns_queries_today=200, queries_blocked=50, percent_blocked=25.0,
+            domains_on_blocklist=5000, unique_clients=10,
+            queries_cached=80, queries_forwarded=70,
+        ),
+    ])
+    for i in range(20):
+        db_session.add(QueryLog(
+            instance_id=instance.id,
+            timestamp=now - timedelta(minutes=i),
+            domain=f"ads{i % 3}.example",
+            client_ip="10.0.0.5", client_name="laptop",
+            status="GRAVITY" if i % 2 == 0 else "OK",
+            query_type="A", reply_type="IP", reply_time_ms=1.5,
+        ))
+    await db_session.commit()
+    return instance
+
+
+# ── /api/stats/summary ───────────────────────────────────────────────────────
+
+
+async def test_summary_unauth_returns_401(client):
+    resp = await client.get("/api/stats/summary")
+    assert resp.status_code == 401
+
+
+async def test_summary_returns_aggregated_payload(authed_client, seed_data):
+    resp = await authed_client.get("/api/stats/summary")
+    assert resp.status_code == 200
+    body = resp.json()
+    # Aggregated shape — totals across all instances
+    assert "totals" in body
+    assert "instances" in body
+    assert isinstance(body["instances"], list)
+
+
+async def test_summary_per_site_scopes_to_site_instances(authed_client, seed_data):
+    """The per-site variant filters to instances in that site only."""
+    resp = await authed_client.get("/api/sites/main/stats/summary")
+    assert resp.status_code == 200
+    body = resp.json()
+    # All returned instances belong to 'main'
+    for inst in body.get("instances", []):
+        assert inst.get("site_slug") == "main" or inst.get("site_slug") is None
+
+
+# ── /api/stats/history ───────────────────────────────────────────────────────
+
+
+async def test_history_returns_buckets(authed_client, seed_data):
+    """24h history endpoint returns time-bucketed counts."""
+    resp = await authed_client.get("/api/stats/history?hours=24")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "buckets" in body
+    assert isinstance(body["buckets"], list)
+
+
+async def test_history_unauth_returns_401(client):
+    resp = await client.get("/api/stats/history")
+    assert resp.status_code == 401
+
+
+# ── /api/stats/top ───────────────────────────────────────────────────────────
+
+
+async def test_top_returns_blocked_and_clients(authed_client, seed_data):
+    """The /top endpoint yields top blocked domains + top clients."""
+    resp = await authed_client.get("/api/stats/top?hours=24&limit=10")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "top_blocked" in body
+    assert "top_clients" in body
+    # We seeded 3 distinct ads*.example domains — at least one should appear.
+    assert len(body["top_blocked"]) >= 1
+
+
+async def test_top_per_site_returns_buckets(authed_client, seed_data):
+    resp = await authed_client.get("/api/sites/main/stats/top?hours=24&limit=10")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "top_blocked" in body
+    assert "top_clients" in body

--- a/tests/integration/test_web_ui.py
+++ b/tests/integration/test_web_ui.py
@@ -1,0 +1,221 @@
+"""Tests for app/main.py web-UI routes — the Jinja-rendered pages
+behind /, /dashboard, /queries, /settings, /combined, /change-password,
+/login, /logout.
+
+The integration suite already covers /api/* — these tests pin the HTML
+routes' status codes, redirects-when-not-authed, and presence of a few
+recognisable bytes in the response body.
+"""
+from __future__ import annotations
+
+
+# ── Anonymous → /login redirect ──────────────────────────────────────────────
+
+
+async def test_root_redirects_to_login_when_anonymous(client):
+    resp = await client.get("/", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith("/login")
+
+
+async def test_dashboard_redirects_to_login_when_anonymous(client):
+    resp = await client.get("/dashboard/main", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+async def test_queries_redirects_to_login_when_anonymous(client):
+    resp = await client.get("/queries", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+async def test_settings_redirects_to_login_when_anonymous(client):
+    resp = await client.get("/settings", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+async def test_combined_redirects_to_login_when_anonymous(client):
+    resp = await client.get("/combined", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+async def test_change_password_redirects_to_login_when_anonymous(client):
+    resp = await client.get("/change-password", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+# ── /login GET ───────────────────────────────────────────────────────────────
+
+
+async def test_login_page_renders_html(client):
+    resp = await client.get("/login")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert b"<form" in resp.content
+
+
+# ── Authenticated routes render ──────────────────────────────────────────────
+
+
+async def test_root_renders_dashboard_when_authed(authed_client):
+    resp = await authed_client.get("/")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+async def test_dashboard_for_site_renders_when_authed(authed_client):
+    resp = await authed_client.get("/dashboard/some-slug")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+async def test_queries_renders_when_authed(authed_client):
+    resp = await authed_client.get("/queries")
+    assert resp.status_code == 200
+
+
+async def test_queries_for_site_renders_when_authed(authed_client):
+    resp = await authed_client.get("/queries/some-slug")
+    assert resp.status_code == 200
+
+
+async def test_settings_renders_when_authed(authed_client):
+    resp = await authed_client.get("/settings")
+    assert resp.status_code == 200
+
+
+async def test_settings_for_site_renders_when_authed(authed_client):
+    resp = await authed_client.get("/settings/some-slug")
+    assert resp.status_code == 200
+
+
+async def test_combined_renders_when_authed(authed_client):
+    resp = await authed_client.get("/combined")
+    assert resp.status_code == 200
+
+
+async def test_change_password_renders_when_authed(authed_client):
+    resp = await authed_client.get("/change-password")
+    assert resp.status_code == 200
+    assert b"<form" in resp.content
+
+
+# ── /login POST ──────────────────────────────────────────────────────────────
+
+
+async def test_login_form_post_with_valid_creds_redirects_home(client, test_user):
+    user, password = test_user
+    resp = await client.post(
+        "/login",
+        data={"username": user.username, "password": password},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/"
+    # Cookie set so the next request is authenticated.
+    assert "session_token" in resp.cookies
+
+
+async def test_login_form_post_with_invalid_creds_returns_401_html(
+    client, test_user,
+):
+    user, _ = test_user
+    resp = await client.post(
+        "/login",
+        data={"username": user.username, "password": "WRONG"},
+    )
+    assert resp.status_code == 401
+    assert b"Invalid username or password" in resp.content
+
+
+async def test_login_form_post_with_password_change_required_redirects_to_change(
+    client, test_user, db_session,
+):
+    """A user flagged for forced password change is sent to
+    /change-password instead of /."""
+    from app.models.user import User
+    from sqlalchemy import select
+
+    user, password = test_user
+    fresh = (
+        await db_session.execute(select(User).where(User.id == user.id))
+    ).scalar_one()
+    fresh.password_change_required = True
+    await db_session.commit()
+
+    resp = await client.post(
+        "/login",
+        data={"username": user.username, "password": password},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/change-password"
+
+
+# ── /logout ──────────────────────────────────────────────────────────────────
+
+
+async def test_logout_redirects_to_login_and_clears_cookie(authed_client):
+    resp = await authed_client.get("/logout", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/login"
+
+
+# ── /change-password POST validation ─────────────────────────────────────────
+
+
+async def test_change_password_form_short_returns_422(authed_client, test_user):
+    _, old_pw = test_user
+    resp = await authed_client.post(
+        "/change-password",
+        data={
+            "current_password": old_pw,
+            "new_password": "short",
+            "confirm_password": "short",
+        },
+    )
+    assert resp.status_code == 422
+    assert b"at least 8" in resp.content.lower() or b"at least" in resp.content
+
+
+async def test_change_password_form_mismatch_returns_422(authed_client, test_user):
+    _, old_pw = test_user
+    resp = await authed_client.post(
+        "/change-password",
+        data={
+            "current_password": old_pw,
+            "new_password": "newpass-12345",
+            "confirm_password": "DIFFERENT-12345",
+        },
+    )
+    assert resp.status_code == 422
+
+
+async def test_change_password_form_wrong_current_returns_422(
+    authed_client,
+):
+    resp = await authed_client.post(
+        "/change-password",
+        data={
+            "current_password": "wrong",
+            "new_password": "newpass-12345",
+            "confirm_password": "newpass-12345",
+        },
+    )
+    assert resp.status_code == 422
+
+
+async def test_change_password_form_success_redirects_home(
+    authed_client, test_user,
+):
+    _, old_pw = test_user
+    resp = await authed_client.post(
+        "/change-password",
+        data={
+            "current_password": old_pw,
+            "new_password": "newpass-12345",
+            "confirm_password": "newpass-12345",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/"


### PR DESCRIPTION
## Summary
Big batch — 110 new tests pushing coverage from 62% to **76.41%**. Companion to PR #39 (collector deep-dive). Together they take us from the original 57% baseline to within a few percent of the 80% target.

## Coverage moves
| File | Before | After |
|------|-------:|------:|
| config_loader.py | 12% | 90% |
| main.py | 41% | 60% |
| pihole_version_check.py | 25% | 71% |
| pushover.py | 43% | 59% |
| api/queries.py | 29% | 50% |
| api/domains.py | 32% | 69% |
| api/stats.py | 24% | 57% |
| api/sites.py | 53% | 65% |
| **Total** | **62.44%** | **76.41%** |

## What lands (10 new test files, 110 tests)
- \`test_config_loader.py\` (7) — sync_sites_and_instances orphan detection, reactivation, Main reassignment, in-place rename with slug history
- \`test_web_ui.py\` (23) — every web UI route handler + login form + change-password validation
- \`test_stats_api.py\` (7) — /api/stats/summary + history + top, global + per-site
- \`test_queries_api_filters.py\` (10) — pagination, filters (domain/client/blocked), sort, per-site, /clients aggregation
- \`test_pihole_version_check.py\` (6) — compute_update_available, check_now, transient-failure preservation
- \`test_domains_api.py\` (6) — block/unblock cluster fan-out (master + replica), readonly-key 403
- \`test_pushover_advanced.py\` (11) — _post HTTP via respx, validate, per-site config + alert toggles
- \`test_settings_services.py\` (8) — session_settings, poll_settings, site_settings round-trips
- \`test_remaining_apis.py\` (19) — /api/sites PATCH + slug history, /api/auth session-timeout + list-keys, /api/version, /api/display-settings, /api/poll-settings, /api/instances DELETE
- \`test_more_apis.py\` (11) — instance stale lists, slug-history-410, pushover load_settings + per-site notifications

## Coverage gate ratcheted: 60% → 75%
Current actual is 76.41%; the new floor (\`--cov-fail-under=75\` in test.yml) leaves a 1.4% buffer.

## Why not 80%?
The remaining ~4% lives almost entirely in:
- main.py lifespan startup hooks (would need asgi-lifespan to fire properly in tests)
- a handful of edge branches in collector / sync_service that aren't on any hot path
- partial coverage of api/_site_dep redirects

Hand-rolling tests for those is diminishing-returns territory. 76% gives us regression guards on every meaningful path; the last 4% is defensive code with low practical risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)